### PR TITLE
Sync develop with main (matrix move semantics)

### DIFF
--- a/projects/LINALG/src/Eigen_Impl/cl_Matrix_Eigen_Dynamic.hpp
+++ b/projects/LINALG/src/Eigen_Impl/cl_Matrix_Eigen_Dynamic.hpp
@@ -431,6 +431,24 @@ namespace moris
             }
 
             /**
+             * Move constructor.
+             * Enables efficient reallocation of containers holding matrices.
+             * Uses Eigen's optimized move operations for the underlying data.
+             *
+             * @param[in] other Matrix to move from (will be left in valid but unspecified state).
+             */
+            Matrix(Matrix&& other) noexcept = default;
+
+            /**
+             * Move assignment operator.
+             * Enables efficient swap/move operations without deep copying.
+             *
+             * @param[in] other Matrix to move from.
+             * @return Reference to this matrix.
+             */
+            Matrix& operator=(Matrix&& other) noexcept = default;
+
+            /**
              * Returns the length of a vector. Thows error neither rows nor cols are equal 1.
              */
             size_t

--- a/projects/LINALG/test/op_move.cpp
+++ b/projects/LINALG/test/op_move.cpp
@@ -17,6 +17,7 @@
 #include "fn_all_true.hpp"
 #include "fn_isempty.hpp"
 #include "fn_print.hpp"
+#include <vector>
 
 namespace moris
 {
@@ -37,6 +38,63 @@ namespace moris
         REQUIRE( all_true(Cmatrix == Amatrix) );
 
         REQUIRE(isempty(Bmatrix));
+    }
+
+    TEST_CASE("moris::Matrix native move constructor", "[linalgebra],[move_semantics]")
+    {
+        // Create original matrix with known values
+        Matrix<DDRMat> original(10, 10, 1.5);
+        original(0, 0) = 42.0;
+        original(9, 9) = 99.0;
+
+        // Use move constructor
+        Matrix<DDRMat> moved(std::move(original));
+
+        // Verify moved matrix has correct dimensions and values
+        REQUIRE(moved.n_rows() == 10);
+        REQUIRE(moved.n_cols() == 10);
+        REQUIRE(moved(0, 0) == 42.0);
+        REQUIRE(moved(9, 9) == 99.0);
+        REQUIRE(moved(5, 5) == 1.5);
+    }
+
+    TEST_CASE("moris::Matrix native move assignment", "[linalgebra],[move_semantics]")
+    {
+        // Create source matrix
+        Matrix<DDRMat> source(5, 5, 2.0);
+        source(2, 2) = 7.0;
+
+        // Move assign to target
+        Matrix<DDRMat> target;
+        target = std::move(source);
+
+        // Verify target has correct dimensions and values
+        REQUIRE(target.n_rows() == 5);
+        REQUIRE(target.n_cols() == 5);
+        REQUIRE(target(2, 2) == 7.0);
+        REQUIRE(target(0, 0) == 2.0);
+    }
+
+    TEST_CASE("moris::Matrix vector push_back with move semantics", "[linalgebra],[move_semantics]")
+    {
+        // This test verifies that std::vector can use move semantics
+        // when reallocating, avoiding deep copies
+
+        std::vector<Matrix<DDRMat>> vec;
+        // Intentionally NOT reserving to force reallocations
+
+        for (int i = 0; i < 100; ++i)
+        {
+            Matrix<DDRMat> temp(4, 4, static_cast<real>(i));
+            vec.push_back(std::move(temp));
+        }
+
+        REQUIRE(vec.size() == 100);
+
+        // Verify data integrity after reallocations
+        REQUIRE(vec[0](0, 0) == 0.0);
+        REQUIRE(vec[50](0, 0) == 50.0);
+        REQUIRE(vec[99](0, 0) == 99.0);
     }
 }
 


### PR DESCRIPTION
develop and main diverged: main (the default branch) carries the Matrix move-semantics work merged via PR #3, while develop received the EXA single-runner via PR #4. This brings main's 3 commits into develop so there is one line of truth; merge preview shows no conflicts.

Going forward suggestion: features -> develop, develop -> main for releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)