### PR TITLE
Performance report, native GCMMA, OPT robustness, SDF reinitialization

### DIFF
--- a/.claude/skills/baseline-moris/SKILL.md
+++ b/.claude/skills/baseline-moris/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: baseline-moris
+description: Use when starting a new MORIS feature, code change, or experiment — BEFORE editing any source. Symptoms — "add a parameter to MORIS", "implement/change the solver/IWG/GEN/optimizer", starting work on a MORIS branch, about to modify projects/, "let's add X to MORIS". Establishes a known-good reference (green build + tests AND a captured reference run) so a later regression is detectable and attributable to your change.
+---
+
+# Baseline MORIS Before a Feature
+
+## Overview
+
+Before changing MORIS, capture ground truth so that a later failure is unambiguously attributable to
+*your* change and you have a concrete reference to diff against. The trap: **a green build is
+necessary but NOT sufficient.** What actually regresses in MORIS is *run behavior* — a converged
+objective, a design, a sensitivity — which the unit tests do not cover. And MORIS runs are slow
+(minutes to hours), so the reference run must be captured **up front, before you touch code** — after
+the fact you can no longer separate your change from the baseline.
+
+Pairs with: `triage-moris-runs` (your baseline IS the reference that makes triage possible) and
+`understand-moris-input-deck` (to read the deck you are baselining).
+
+## The baseline checklist — do all of it before editing source
+
+1. **Audit the tree state.** `git status` — what is already uncommitted? Know this so your later diff
+   is clean and you do not attribute pre-existing changes to yourself. Do **not** delete or stash
+   untracked work that isn't yours (generated `results/`, receipts, or someone's WIP). If not on a
+   feature branch, branch first.
+
+2. **Pin the reference point.** Record `git rev-parse --short HEAD` and the build date. For changes
+   where "is it the deck or my code?" may come up later, keep a **pre-change binary** (copy
+   `build_opt/projects/mains/moris`, or use a pinned clone) so you can reproduce-on-old to localize.
+
+3. **Build green FIRST, on the current tree, before adding anything.** `cd build_opt && ninja -j2
+   <target>` must be clean *now*. If it isn't, understand/fix that before your change — otherwise a
+   later failure is ambiguous. Use **`-j2`**: the build is memory-hungry; higher `-j` exhausts RAM.
+
+4. **Tests green.** Run the relevant suite and record the count:
+   `./projects/<MOD>/test/bin/<MOD>-test.exe` (e.g. `OPT-test.exe`) or `ctest -L <LABEL>`.
+
+5. **Capture a reference RUN — the critical, MORIS-specific step.** Pick the deck/case your change
+   will affect and run it NOW, unchanged, saving into a `baseline/` dir:
+   - `Parameter_Receipt.xml` — what MORIS actually used,
+   - `moris_run.log` — objective/constraint trajectory + eval count,
+   - the final-design exo (the VIS `<name>.exo.<np>.<r>` set) or a render.
+   This is your falsifier: after the change you diff the new run against it. Without it you cannot tell
+   whether your feature changed the answer.
+
+6. **Fix the comparison protocol up front.** Record the **MPI rank count** you will standardize on —
+   different `np` gives a different result (decomposition noise; see `triage-moris-runs`) — and run the
+   after-change comparison at the *same* `np`, same deck, same mesh.
+
+## Adding a tunable: the three-layer PRM pattern
+
+Exposing a new MORIS parameter is always three edits + a test:
+1. `projects/PRM/src/fn_PRM_<MODULE>_Parameters.hpp` — `tParameterList.insert("key", default)`. **The
+   default must be current behavior (a no-op)** so the baseline run is reproduced bit-for-bit.
+2. The consuming module — read it (`aParameterList.get<T>("key")`, guard with `.exists()` if optional)
+   and act on it.
+3. `projects/<MODULE>/test/` — a unit test covering the parameter on and off.
+
+Mirror an existing precedent: `sdf_reinit_mode`, `reinit_in_place`, `grad_clip_factor`.
+
+## Common mistakes
+
+- **Green build mistaken for a baseline.** Unit-green ≠ behavior-captured. Run the reference deck
+  *before* editing — afterwards you can't separate your change from the baseline. (This is the #1 gap.)
+- **Starting on a dirty tree.** Uncommitted unrelated changes fold into your diff and can break your
+  run (this has bitten — a pile of stray GEN/MTK edits crashed a run mid-triage). Audit first; build
+  green with what's there before adding yours.
+- **New-param default changes behavior.** The default must reproduce the baseline run exactly; verify
+  the baseline deck output is unchanged after the (default-off) param is added.
+- **No `np` recorded.** You later compare at a different rank count and chase decomposition noise.
+- **Deleting untracked artifacts to "tidy up".** Generated results/receipts may be a reference. Leave
+  them.

--- a/.claude/skills/comparative-study-moris/SKILL.md
+++ b/.claude/skills/comparative-study-moris/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: comparative-study-moris
+description: Use when running a parametric or comparison study across MORIS runs — sweeping a parameter, mesh resolution, optimizer, or deck variant to quantify its effect on the result. Symptoms — "compare step_size 0.01 vs 0.05", "how does mesh resolution affect the design", "sweep parameter P", "which optimizer is better", "study the effect of X", building a run matrix, comparing converged objectives/designs across runs.
+---
+
+# Comparative Study Across MORIS Runs
+
+## Overview
+
+A comparative study isolates the effect of **one** factor on a MORIS result by running a matrix where
+everything else is held constant. The entire value is in the controls — a sloppy study yields a
+confident but wrong verdict. Two failure modes dominate:
+
+1. **Comparing non-converged runs.** Truncating every arm at a short fixed iteration budget and
+   declaring a winner measures *transient descent speed*, not the *optimum*. A method that moves faster
+   early can look "better" at iter 50 yet converge to the same or a worse design. Either run to
+   convergence, or state explicitly that you are comparing transient behavior.
+2. **Confounded or noise-dominated comparison.** More than one thing changed between arms, or the
+   measured effect is smaller than the run-to-run noise floor.
+
+Pairs with: `baseline-moris` (capture the reference first) and `triage-moris-runs` (when one arm
+differs unexpectedly — the verify/receipt-diff disciplines there apply here too).
+
+## Design the matrix — one factor at a time
+
+- Start every arm from **one common ancestor deck**. Verify it: `sha256sum`/`diff` must show that arms
+  differ in **exactly** the intended line(s). Vary one knob; hold mesh, `np`, optimizer, physics,
+  seeding, and iteration budget fixed.
+- Record the matrix explicitly: a table of {arm → varied value | everything-else fixed}. One dir per
+  arm under `runs/studies/<study>/`.
+- **Hold `np` constant across arms.** Different rank counts give a different decomposition → ~1 %
+  objective spread (the noise floor; see `triage-moris-runs`). If the effect you're measuring is below
+  that, it's noise — enlarge the effect, or run replicates.
+
+## Run it
+
+```bash
+moris-run arm.cpp --compile-only -o .
+mpirun -np N $MORISROOT/build_opt/projects/mains/moris ./arm.so > moris_run.log 2>&1
+```
+- **Run to convergence** — `max_its` large enough that the design stops changing and KKT `norm_drop`
+  is hit — not a short fixed budget, unless transient comparison is the explicit goal. Confirm each log
+  ended with `ElapsedWallTime` (clean finish) and the objective plateaued (`grep Objective: log | tail`).
+- If you must modify the deck to make it run (library name, solver backend, iteration count), apply the
+  **same** change to **every** arm, record it, and verify the modified deck still reproduces a
+  known-good baseline before trusting the study — a workaround can interact with the factor under test.
+
+## Verify each arm used the intended settings — from the receipt, not the source
+
+- `Parameter_Receipt.xml`: the varied key holds the intended value in each arm.
+- **Receipt-diff the arms section by section** (`awk '/^\t<SEC>/,/^\t<\/SEC>/'` over OPT/HMR/XTK/GEN/
+  FEM/SOL): confirm **exactly** the intended parameter differs and nothing else moved. A diff that is
+  inert (a `discretization` bound on a `discretization_mesh_index < 0` geometry, a dead property) is
+  fine — but you must recognize it as inert (see `triage-moris-runs` D4), not ignore it.
+- Cross-check the algorithm's runtime echo in the log if it prints its config.
+
+## Present the comparison
+
+- **Numbers:** one table — final objective, constraint, eval count, wall time per arm — and **state
+  whether each converged**.
+- **Designs:** render every arm with the **same** script, same color / scale / extent, and compose into
+  one figure (side-by-side or grid). Render the final-design VIS exo (`<name>.exo.<np>.<r>`), not the
+  `GEN_*.e-s.*` evolution snapshots. Identical rendering is what makes the visual comparison honest —
+  different scales/crops make designs look more different than they are.
+- **Verdict with caveats:** name the noise floor, say whether the comparison is at convergence or
+  transient, and what would strengthen it (longer budget, replicates, a third level).
+
+## Common mistakes
+
+- **Winner from truncated runs.** "0.05 beats 0.01 at iter 50" ≠ "0.05 is better" if neither converged.
+  Run to convergence or label the result transient.
+- **Confounded matrix.** Two knobs changed (e.g. `step_size` *and* `np`, or the factor *and* a deck
+  workaround). Receipt-diff to prove one-factor before reporting.
+- **Effect inside the noise floor.** A sub-1 % objective gap at different `np` is decomposition noise,
+  not a finding.
+- **Inconsistent rendering.** Different color scales/crops exaggerate differences. One script, one
+  scale, composed panels.
+- **Trusting deck source over the receipt.** Verify the live value per arm; a run/dir name (e.g.
+  `step001`) may not reflect what actually ran.

--- a/.claude/skills/triage-moris-runs/SKILL.md
+++ b/.claude/skills/triage-moris-runs/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: triage-moris-runs
+description: Use when diagnosing a MORIS optimization/simulation run that crashed, aborted, segfaulted, hit a NaN, stalled or diverged, converged to an unexpected design, or differs from another run that "should be the same". Symptoms — "why did this run X", "these two runs give different results", gradient explosion, ADV-consistency assert, "does not match", restart loop, Belos not converged, optimizer froze/lattice instead of truss, comparing two Parameter_Receipt.xml.
+---
+
+# Triage a MORIS Run
+
+## Overview
+
+Triaging a MORIS run is **differential debugging**: you explain a run by contrast with a reference
+where the behavior differs. Two rules dominate, because violating either produces a confident wrong
+answer:
+
+1. **The deck source lies; the receipt and the log are ground truth.** What a `.cpp`/`.py` says is
+   not what MORIS ran — pymoris codegen has silently dropped keys (e.g. `step_size`/`penalty`), and a
+   `.so` inlines its own parameter lists at *its* compile time. Read `Parameter_Receipt.xml` (what
+   MORIS actually used) and `moris_run.log` (what actually happened).
+2. **A plausible mechanism is a hypothesis, not a conclusion.** The decisive test is a controlled
+   re-run with exactly one knob changed — not a story about why a parameter "should" matter. Run it.
+
+**REQUIRED BACKGROUND for deck structure:** use the `understand-moris-input-deck` skill to read any
+deck (criteria ordering, GEN↔FEM string links, mesh-set names).
+
+## The five disciplines
+
+**D1 — Anchor on a falsifier / reference.** If something "should" work, find where it *did* (a
+different resolution, an older pinned binary, a reference deck, an earlier commit) — that's your
+reference. If none exists, *create* one by toggling to a known-good configuration. With no reference
+you are guessing, not triaging.
+
+**D2 — Diff the receipt, section by section, not the deck.** `Parameter_Receipt.xml` has one block per
+module: `OPT HMR XTK GEN FEM SOL MSI VIS MORISGENERAL`. Extract and diff each:
+```bash
+ex(){ awk "/^\t<$2>/,/^\t<\/$2>/" "$1/Parameter_Receipt.xml" | sed 's/^[[:space:]]*//; s/&quot;/"/g'; }
+diff <(ex runA HMR) <(ex runB HMR)        # mesh identical? (number_of_elements_per_dimension, orders)
+diff <(ex runA OPT) <(ex runB OPT)        # optimizer + algorithm params identical?
+```
+The receipt also captures what the deck *omitted* (it shows the resolved defaults) — that is how you
+catch silent codegen gaps.
+
+**D3 — Change exactly ONE variable.** Hold mesh, MPI rank count, optimizer, and deck constant except
+the one knob under test. A comparison that differs in two things (e.g. `np` *and* a parameter) cannot
+attribute the result to either. Most "mysterious" run differences are confounded comparisons.
+
+**D4 — Verify a flagged parameter is actually LIVE before blaming it.** A diff is not a cause. Check
+the parameter is in force:
+- A GEN geometry with `discretization_mesh_index < 0` is **not a design variable** — its
+  `discretization_lower/upper_bound` are inert (no ADVs created for it). Only geometries with
+  `discretization_mesh_index = 0` (or a real B-spline index) are optimized.
+- A FEM `Property`/`IWG`/`CM`/`SP` defined but referenced by nothing is **dead** — `grep` its name; one
+  hit (its own definition) = unused.
+- User-function *bodies* (geometry fields, load, `compute_objectives`) are **not** in the receipt —
+  `diff` them directly between decks before concluding the decks match.
+
+**D5 — Confirm by controlled re-run, never decline it.** Re-run with one knob flipped, or at matched
+config. **Bit-for-bit reproduction proves equivalence** (two MMA runs cannot share a 15-digit,
+all-iterations-identical objective trajectory unless every live input matches). "No need to re-run, the
+mechanism is clear" is the signature of a wrong triage.
+
+## MPI rank count is a real variable
+
+Different `np` → different XTK domain decomposition → different floating-point reduction order →
+**different local minimum** in a non-convex TO problem. Expect a run-to-run objective spread of a
+percent or so purely from `np`. When comparing runs, hold `np` constant (check `Procs Used` in each
+log header) or you will misattribute decomposition noise to the deck.
+
+## Reading the log (grep the diagnostic stream)
+
+```bash
+grep -c "Objective:" log            # eval count; tail | grep -v nan for the converged value
+grep "GradDebug" log | tail         # obj_norm/obj_max (gradient health), at_lower/at_upper (bound saturation), n_advs (DOF)
+grep -c "Number of optimization variables" log   # restart/re-init count; the value = DOF (changes on remesh)
+grep -cE "objective scale ->|Gradient clip|non-finite design" log  # which robustness path engaged
+grep -nE "Reason:|Segmentation|out_of_range|Aborted" log   # fatal cause
+grep "MinADV: -nan" log             # NaN-poisoned design vector (overflow upstream)
+grep "ElapsedWallTime =" log        # present == clean finish
+```
+Healthy XFEM design gradients are O(0.1); `obj_max` to ~1e8 is tolerated raw, ~1e10 overflows the
+GCMMA subproblem to NaN. A self-contradictory line (`obj_norm=1e8` with `obj_max=1e-38`) means a clip
+fired between the two measurements.
+
+## Band-aid vs root cause
+
+A run kept alive by a gradient clip, every-step reinit, or restart-on-NaN may be **masking an
+ill-conditioned setup**, not solving it. Localize the cause:
+- Reproduce on a **pinned/older binary** (e.g. `moris_8a328272e`) → if it also fails, the cause is the
+  deck/conditioning, not your code change. Run a deck against another binary's headers by compiling with
+  that `MORISROOT`.
+- Toggle the band-aid off and fix conditioning instead (tight `discretization` bounds ≈ one element
+  diagonal, adaptive remeshing) — often the band-aid becomes unnecessary.
+
+## Run mechanics
+
+```bash
+spack env activate /home/doble/codes && source ~/.bashrc_moris
+# direct binary also needs MKL on the path (moris-run injects it automatically):
+export MKL_DIR=/home/doble/codes/spack/opt/spack/linux-x86_64_v4/intel-oneapi-mkl-2024.2.2-4xeqh62vh6x3j5xlqhlyuawrgkwdquib
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$MKL_DIR/mkl/2024.2/lib
+moris-run deck.cpp --compile-only -o .                       # deck.cpp -> deck.so (receipt-faithful)
+mpirun -np 8 $MORISROOT/build_opt/projects/mains/moris ./deck.so > moris_run.log 2>&1
+```
+- The moris-run launch shell has `set -e`: a leading `pkill`/`pgrep` returning 1 aborts the whole
+  compound command before later lines — guard with `|| true` or run as separate commands.
+- Run output goes under `$MORIS_RUNS_DIR` (`runs/`), never inside a git repo or `studies/`.
+- Render the **final design** from the VIS exo (`<name>.exo.<np>.<r>`); the `GEN_*.e-s.*` files are
+  per-iteration *evolution* snapshots (animation only, huge — prune them to reclaim space).
+
+## Common mistakes
+
+- **Confounded comparison** — comparing two runs that differ in `np` *and* a parameter, then blaming
+  the parameter. Match everything but one knob (D3).
+- **Blaming an inert parameter** — flagging `discretization_*_bound = ±1` on a geometry whose
+  `discretization_mesh_index = -2` (not a design var), or a dead `PropFlux`. Verify it's live (D4).
+- **Mechanism instead of experiment** — building a regularization story and declining the one-knob
+  re-run that would confirm or kill it (D5).
+- **Trusting the deck source** — concluding from `.cpp`/`.py` instead of the receipt; the run name
+  (e.g. `step001`) may not reflect what ran (it inherited the default 0.01, never set it).
+- **Reading the deck linearly** — use `understand-moris-input-deck`; criteria order is GEN's
+  `IQI_types`, not FEM IQI order.
+- **Treating NaN/`obj_max=1e10` as the disease** — it is a symptom of small-cut-cell ill-conditioning
+  upstream; chase the conditioning (bounds, remeshing), not the explosion.

--- a/.claude/skills/understand-moris-input-deck/SKILL.md
+++ b/.claude/skills/understand-moris-input-deck/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: understand-moris-input-deck
+description: Use when reading, explaining, debugging, modifying, or porting a MORIS C++ input deck — an EXA example or any .cpp that defines OPTParameterList/HMRParameterList/GENParameterList/FEMParameterList etc. Symptoms: "what does this input file do", "where is the objective/geometry/BC defined", unfamiliar aParameterLists.set keys, string names that match across blocks, set names like HMR_dummy_c_p2 / iside_ / ghost_p1.
+---
+
+# Understand a MORIS Input Deck
+
+## Overview
+
+A MORIS input deck is **one C++ file** (in `namespace moris`, wrapped in `extern "C"`) that fully
+configures a simulation. It has no MORIS logic — only data: top-of-file constants, one
+`*ParameterList(Module_Parameter_Lists&)` function per module, and user callbacks. Everything is
+**string-coupled**: names defined in one block are referenced by string in others, with no compiler
+check. Read by *tracing those links*, not top-to-bottom.
+
+Don't go spelunking through factories/enums to answer structural questions — the structure below is
+fixed across every deck. Only open other files to **decode a specific key** (see last section).
+
+## Source-of-truth documentation
+
+Before reverse-engineering, check the authoritative docs (all under `moris/share/doc/`):
+
+- **`Using_Moris.dox`** (`@page UsingMoris`) — the canonical guide to *writing* input decks: input-file
+  steps, recommended HMR/SOL settings, convergence tweaks, and the sweep sensitivity-check workflow.
+  Start here for "how should this be set up / why."
+- **`Wrk_HMR_XTK_GEN_FEM_Workflow.dox`** — the module workflow, and a table mapping each
+  `*ParameterList` function to its `fn_PRM_<MODULE>_Parameters.hpp` header (the per-key decode source).
+  Companion docs `Wrk_STK_XTK_WorkFlow.dox`, `Wrk_STK_FEM_WorkFlow.dox` cover the non-XFEM workflows.
+- **`mesh_generation/main.pdf`** (+ `mesh_generation/examples/`) — the XML-driven mesh-generation
+  input format (separate from the optimization decks here).
+- **`projects/PRM/src/fn_PRM_<MODULE>_Parameters.hpp`** — the authoritative, code-level list of every key
+  and its default (see last section).
+- **The EXA decks themselves** — `Using_Moris.dox` explicitly says to start from an existing example with
+  the features you want and adapt it; `projects/EXA/*/` is the de-facto reference library.
+
+These are reference, not gospel: defaults and enums live in code, so when a doc and the `fn_PRM_*`/enum
+source disagree, trust the source.
+
+## Read order
+
+1. **Top-of-file constants** (`tName`, `tIsOpt`, `tMaxMass`, set-name strings…) — these parameterize
+   everything below. The "Derived parameters" section assembles mesh-set name strings.
+2. **`OPTParameterList`** — is `is_optimization_problem` true? `problem = "user_defined"` means the
+   objective/constraints are the C++ callbacks in this file. Check **which** algorithm `OPT::ALGORITHMS`
+   adds: `Optimization_Algorithm_Type::GCMMA`/`SQP`/`LBFGS` is a real design run, but `::SWEEP` is a
+   **finite-difference sensitivity check** (keys `num_evaluations_per_adv`, `finite_difference_type`,
+   `finite_difference_adv_indices`, `hdf5_path`) — not optimization, even though `is_optimization_problem`
+   is true. Don't equate "optimization problem = design run."
+3. **`GENParameterList`** — geometry + design variables. `GEN::GEOMETRIES` entries define level-set
+   primitives (`gen::Field_Type::SUPERELLIPSE`, `field_array` for tiled holes, or `USER_DEFINED` +
+   `field_function_name`). The `discretization_*` keys (set only when `tIsOpt`) make a field's B-spline
+   coefficients the **ADVs**, bounded by `discretization_lower/upper_bound`. `phase_table` maps geometry
+   sign combinations → material phase index. Two design-variable pathways reach the physics — contract C.
+4. **`FEMParameterList`** — the physics (see contract B below).
+5. **`SOL`/`MSI`/`VIS`** — solver type, DOF order, Exodus output. Multiphysics decks stage sub-solvers:
+   several `NONLINEAR_SOLVERS`/`NONLINEAR_ALGORITHMS` coupled by NLBGS, `TSA_Nonlinear_Solver` selecting
+   the driver, `TIME_CONTINUITY_DOF` IWGs for transient fields. Don't assume a single solve.
+
+## The two non-obvious contracts
+
+**A. Criteria ordering links GEN → the OPT callbacks.** The order of names in GEN's
+`set("IQI_types", ...)` **is** the index order of the `aCriteria` vector passed to
+`compute_objectives`/`compute_constraints`. In `Levelset_Boxbeam.cpp`, `IQI_types` =
+`[StrainEnergy_Frame, StrainEnergy_Interior, Volume_Interior, Perimeter_Void]`, so `aCriteria(0)` is
+frame strain energy, `aCriteria(2)` is interior volume, etc. The objective/constraint callbacks index
+this vector by position — get the order wrong and the math is silently wrong. `compute_d*_dcriteria`
+returns the analytic chain-rule terms; `compute_d*_dadv` usually returns **zeros** because ADV
+sensitivities flow through the FEM adjoint via the criteria.
+
+**B. The FEM block is built bottom-up and linked by string.** Sub-lists are added in this order via
+`aParameterLists( FEM::<SECTION> ).add_parameter_list()`:
+`PROPERTIES → CONSTITUTIVE_MODELS → STABILIZATION → IWG → IQI → COMPUTATION`. Each later layer
+references earlier ones **by name, paired with a role tag**:
+- a CM lists its properties: `"properties", "PropYoungs,YoungsModulus;PropPoisson,PoissonRatio"`
+- an IWG lists its CM/SP/properties: `"leader_constitutive_models", "CMStrucLinIso_Frame,ElastLinIso"`,
+  `"stabilization_parameters", "SPNitscheDirichletBC,DirichletNitsche"`
+- an IQI's `IQI_name` is a user label (referenced by GEN's `IQI_types`); its `IQI_type` enum selects
+  the actual computation. The left side of each pair is the name you defined; the right side is the
+  fixed role the consumer expects. `hack_for_legacy_fem()` at the top of the block is an ordering quirk,
+  not meaningful config.
+
+Properties hold their value in `function_parameters` and a `value_function` (a C++ callback in this
+file, e.g. `Func_Const` returns the constant; `Func_Neumann_U` computes a position-dependent traction).
+
+**C. ADVs reach the physics by one of two pathways.** (1) *Direct geometry:* a `GEN::GEOMETRIES`
+level-set field with `discretization_*` set — the field's B-spline coefficients are the ADVs and they
+move the interface (the Boxbeam case). (2) *PDV-coupled property:* a `GEN::PROPERTIES` entry (often
+`gen::Field_Type::SCALED_FIELD`) that `dependencies` on an ADV field and publishes a `pdv_type` (e.g.
+`LS1`); FEM properties then consume that PDV via `value_function` **plus** `dv_dependencies` and
+`dv_derivative_functions` (which supply the design sensitivities). When a deck's design machinery seems
+missing from `GEN::GEOMETRIES`, look for this `PROPERTIES`→`pdv_type`→FEM-`dv_dependencies` chain.
+
+## Mesh-set naming (XTK/GEN convention, not arbitrary)
+
+Set names encode phase and cut status; you don't define them, XTK generates them:
+- `HMR_dummy_c_p2` / `HMR_dummy_n_p2` — bulk cells of **phase 2**; `c` = intersected/cut by interface,
+  `n` = non-cut. `pN` = phase index from `phase_table`.
+- `SideSet_4_n_p2` — external boundary side set 4 (HMR numbers domain sides), phase 2.
+- `iside_b0_2_b1_0` — single-sided interface set between phase 2 and phase 0.
+- `dbl_iside_p0_1_p1_2` — double-sided interface (phase 1 ↔ phase 2), used for Nitsche coupling IWGs.
+- `ghost_p1` — ghost-stabilization set for phase 1 (only when `ghost_stab`/`tUseGhost`).
+
+## Decoding any specific key
+
+A key's **meaning + default** lives in `projects/PRM/src/fn_PRM_<MODULE>_Parameters.hpp` (e.g.
+`fn_PRM_XTK_Parameters.hpp` shows `decomposition_type` defaults to `"conformal"`). A key whose value is a
+C++ **enum** (`IWG_type`, `constitutive_type`, `Field_Type`, …) — its allowed values are the enum in
+`projects/PRM/ENM/src/cl_FEM_Enums.hpp` (and `cl_XTK_Enums.hpp`, etc.), and the enum→class mapping is in
+the matching factory, `projects/FEM/INT/src/<SEC>/cl_FEM_<SEC>_Factory.cpp`. Open these only when a
+specific key's value or valid set is actually in question.
+
+## Common mistakes
+
+- Reading the file linearly instead of tracing string links — you miss the GEN↔FEM and IWG↔CM↔Property graph.
+- Assuming `aCriteria` order matches the FEM IQI definition order. It matches **GEN's `IQI_types`** order.
+- Treating `IQI_name`/`constitutive_name` as meaningful — they're arbitrary labels; the `*_type` enum is what computes.
+- Re-deriving a key's default by guessing instead of opening its `fn_PRM_*` list.
+- Reading a perimeter as a bug because `IQIPerimeter_*` uses `IQI_type::VOLUME` over an *interface* set — integrating 1 over a lower-dimensional set yields its measure (the perimeter). Intentional.

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ CMakeCache.txt
 *.hdf5
 *.h5
 
+# exodus per-iteration series written by optimization runs (NAME.exo.e-s.0001[.nprocs.rank]);
+# NOT bare *.exo/*.e -- committed test fixtures use those extensions
+*.e-s.[0-9]*
+
 
 # Don't commit latex compiler output
 *.fls

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -667,7 +667,9 @@ find_package(Threads)
 option(MORIS_USE_GPERFTOOLS "Use Google Profiling tools (check paths in CMakeLists.txt)." OFF)
 
 if (MORIS_USE_GPERFTOOLS)
-    set( MORIS_CXX_FLAGS "${MORIS_CXX_FLAGS} -I/usr/include/gperftools/ -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free" )
+    # -DWITHGPERFTOOLS activates the gperftools code paths guarded by `#ifdef WITHGPERFTOOLS`
+    # (cl_Profiler CPU profiling and the performance reporter's tcmalloc memory sampling)
+    set( MORIS_CXX_FLAGS "${MORIS_CXX_FLAGS} -DWITHGPERFTOOLS -I/usr/include/gperftools/ -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free" )
 
     link_libraries("-Wl,--no-as-needed -lprofiler -Wl,--as-needed -ltcmalloc")
 endif()

--- a/projects/EXA/runner/runner_main.cpp
+++ b/projects/EXA/runner/runner_main.cpp
@@ -15,6 +15,7 @@
 #include <catch.hpp>
 #include "cl_Communication_Manager.hpp"   // COM/src
 #include "cl_Logger.hpp"                  // MRS/IOS/src
+#include "cl_Performance_Reporter.hpp"    // MRS/IOS/src
 #include "banner.hpp"                     // COR/src
 
 moris::Comm_Manager gMorisComm;
@@ -49,6 +50,9 @@ int main( int argc, char* argv[] )
 
     // Run Tests
     int tRet = Catch::Session().run( argc, argv );
+
+    // emit the consolidated performance report (while MPI is still live)
+    gPerfReporter.finalize();
 
     // finalize MORIS global communication manager
     gMorisComm.finalize();

--- a/projects/GEN/SDF/src/CMakeLists.txt
+++ b/projects/GEN/SDF/src/CMakeLists.txt
@@ -19,6 +19,7 @@ set(HEADERS
     cl_SDF_Facet_Vertex.hpp
     cl_SDF_Facet.hpp
     cl_SDF_Field.hpp
+    cl_SDF_From_Interface.hpp
     cl_SDF_Generator.hpp
     cl_SDF_Line.hpp
     cl_SDF_Mesh.hpp
@@ -43,6 +44,7 @@ set(LIB_SOURCES
     cl_SDF_Facet_Vertex.cpp
     cl_SDF_Facet.cpp
     cl_SDF_Field.cpp
+    cl_SDF_From_Interface.cpp
     cl_SDF_Generator.cpp
     cl_SDF_Line.cpp
     cl_SDF_Mesh.cpp

--- a/projects/GEN/SDF/src/cl_SDF_From_Interface.cpp
+++ b/projects/GEN/SDF/src/cl_SDF_From_Interface.cpp
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2022 University of Colorado
+ * Licensed under the MIT license. See LICENSE.txt file in the MORIS root for details.
+ *
+ *------------------------------------------------------------------------------------
+ *
+ * cl_SDF_From_Interface.cpp
+ *
+ */
+
+#include "cl_SDF_From_Interface.hpp"
+#include "fn_dot.hpp"
+#include "fn_norm.hpp"
+#include "fn_cross.hpp"
+#include "op_minus.hpp"
+#include "op_plus.hpp"
+#include "op_times.hpp"
+
+#include <cmath>
+#include <limits>
+
+namespace moris::sdf
+{
+    //-------------------------------------------------------------------------------
+
+    void
+    SDF_From_Interface::compute(
+            uint                         aNumNodes,
+            const Matrix< DDRMat >&      aNodeCoords,
+            const Matrix< DDRMat >&      aFacetNodeCoords,
+            const Matrix< IndexMat >&    aFacetConn,
+            const Vector< moris_index >& aNodeBulkPhase,
+            moris_index                  aMaterialPhase,
+            Matrix< DDRMat >&            aSDF )
+    {
+        // Get spatial dimension from node coordinates
+        uint tSpatialDim = aNodeCoords.n_cols();
+
+        // Resize output
+        aSDF.set_size( aNumNodes, 1 );
+
+        // For each mesh node, compute distance to interface
+        for ( uint iNode = 0; iNode < aNumNodes; ++iNode )
+        {
+            // Extract node coordinates
+            Matrix< DDRMat > tPoint( tSpatialDim, 1 );
+            for ( uint iDim = 0; iDim < tSpatialDim; ++iDim )
+            {
+                tPoint( iDim ) = aNodeCoords( iNode, iDim );
+            }
+
+            // Compute unsigned distance to nearest facet
+            real tDistance = compute_distance_to_interface(
+                    tPoint,
+                    aFacetNodeCoords,
+                    aFacetConn,
+                    tSpatialDim );
+
+            // Determine sign: material phase = negative, void = positive
+            real tSign = ( aNodeBulkPhase( iNode ) == aMaterialPhase ) ? -1.0 : 1.0;
+
+            // Store signed distance
+            aSDF( iNode ) = tSign * tDistance;
+        }
+    }
+
+    //-------------------------------------------------------------------------------
+
+    real
+    SDF_From_Interface::compute_distance_to_interface(
+            const Matrix< DDRMat >&   aPoint,
+            const Matrix< DDRMat >&   aFacetNodeCoords,
+            const Matrix< IndexMat >& aFacetConn,
+            uint                      aSpatialDim )
+    {
+        real tMinDistance = std::numeric_limits< real >::max();
+
+        uint tNumFacets      = aFacetConn.n_rows();
+        uint tNodesPerFacet  = aFacetConn.n_cols();
+
+        // Loop over all facets
+        for ( uint iFacet = 0; iFacet < tNumFacets; ++iFacet )
+        {
+            real tDistance = 0.0;
+
+            if ( aSpatialDim == 3 && tNodesPerFacet == 3 )
+            {
+                // 3D: Triangle facet
+                moris_index tIdx0 = aFacetConn( iFacet, 0 );
+                moris_index tIdx1 = aFacetConn( iFacet, 1 );
+                moris_index tIdx2 = aFacetConn( iFacet, 2 );
+
+                Matrix< DDRMat > tV0( 3, 1 );
+                Matrix< DDRMat > tV1( 3, 1 );
+                Matrix< DDRMat > tV2( 3, 1 );
+
+                for ( uint iDim = 0; iDim < 3; ++iDim )
+                {
+                    tV0( iDim ) = aFacetNodeCoords( tIdx0, iDim );
+                    tV1( iDim ) = aFacetNodeCoords( tIdx1, iDim );
+                    tV2( iDim ) = aFacetNodeCoords( tIdx2, iDim );
+                }
+
+                tDistance = point_to_triangle_distance( aPoint, tV0, tV1, tV2 );
+            }
+            else if ( aSpatialDim == 2 && tNodesPerFacet == 2 )
+            {
+                // 2D: Line segment facet
+                moris_index tIdx0 = aFacetConn( iFacet, 0 );
+                moris_index tIdx1 = aFacetConn( iFacet, 1 );
+
+                Matrix< DDRMat > tV0( 2, 1 );
+                Matrix< DDRMat > tV1( 2, 1 );
+
+                for ( uint iDim = 0; iDim < 2; ++iDim )
+                {
+                    tV0( iDim ) = aFacetNodeCoords( tIdx0, iDim );
+                    tV1( iDim ) = aFacetNodeCoords( tIdx1, iDim );
+                }
+
+                tDistance = point_to_segment_distance( aPoint, tV0, tV1 );
+            }
+            else
+            {
+                // Fallback: treat as segment between first two nodes
+                moris_index tIdx0 = aFacetConn( iFacet, 0 );
+                moris_index tIdx1 = aFacetConn( iFacet, 1 );
+
+                Matrix< DDRMat > tV0( aSpatialDim, 1 );
+                Matrix< DDRMat > tV1( aSpatialDim, 1 );
+
+                for ( uint iDim = 0; iDim < aSpatialDim; ++iDim )
+                {
+                    tV0( iDim ) = aFacetNodeCoords( tIdx0, iDim );
+                    tV1( iDim ) = aFacetNodeCoords( tIdx1, iDim );
+                }
+
+                tDistance = point_to_segment_distance( aPoint, tV0, tV1 );
+            }
+
+            // Track minimum distance
+            if ( tDistance < tMinDistance )
+            {
+                tMinDistance = tDistance;
+            }
+        }
+
+        return tMinDistance;
+    }
+
+    //-------------------------------------------------------------------------------
+
+    real
+    SDF_From_Interface::point_to_triangle_distance(
+            const Matrix< DDRMat >& aPoint,
+            const Matrix< DDRMat >& aV0,
+            const Matrix< DDRMat >& aV1,
+            const Matrix< DDRMat >& aV2 )
+    {
+        // Edge vectors
+        Matrix< DDRMat > tE0 = aV1 - aV0;    // Edge 0: V0 -> V1
+        Matrix< DDRMat > tE1 = aV2 - aV0;    // Edge 1: V0 -> V2
+        Matrix< DDRMat > tD  = aV0 - aPoint; // Vector from point to V0
+
+        // Precompute dot products
+        real tA = dot( tE0, tE0 );
+        real tB = dot( tE0, tE1 );
+        real tC = dot( tE1, tE1 );
+        real tD0 = dot( tE0, tD );
+        real tD1 = dot( tE1, tD );
+
+        real tDet = tA * tC - tB * tB;
+        real tS   = tB * tD1 - tC * tD0;
+        real tT   = tB * tD0 - tA * tD1;
+
+        // Determine which Voronoi region the point is in
+        if ( tS + tT <= tDet )
+        {
+            if ( tS < 0.0 )
+            {
+                if ( tT < 0.0 )
+                {
+                    // Region 4: closest to V0
+                    tS = clamp01( -tD0 / tA );
+                    tT = 0.0;
+                }
+                else
+                {
+                    // Region 3: closest to edge V0-V2
+                    tS = 0.0;
+                    tT = clamp01( -tD1 / tC );
+                }
+            }
+            else if ( tT < 0.0 )
+            {
+                // Region 5: closest to edge V0-V1
+                tS = clamp01( -tD0 / tA );
+                tT = 0.0;
+            }
+            else
+            {
+                // Region 0: inside triangle
+                real tInvDet = 1.0 / tDet;
+                tS *= tInvDet;
+                tT *= tInvDet;
+            }
+        }
+        else
+        {
+            if ( tS < 0.0 )
+            {
+                // Region 2: closest to edge V0-V2 or V1-V2
+                real tTmp0 = tB + tD0;
+                real tTmp1 = tC + tD1;
+                if ( tTmp1 > tTmp0 )
+                {
+                    real tNumer = tTmp1 - tTmp0;
+                    real tDenom = tA - 2.0 * tB + tC;
+                    tS = clamp01( tNumer / tDenom );
+                    tT = 1.0 - tS;
+                }
+                else
+                {
+                    tS = 0.0;
+                    tT = clamp01( -tD1 / tC );
+                }
+            }
+            else if ( tT < 0.0 )
+            {
+                // Region 6: closest to edge V0-V1 or V1-V2
+                real tTmp0 = tB + tD1;
+                real tTmp1 = tA + tD0;
+                if ( tTmp1 > tTmp0 )
+                {
+                    real tNumer = tTmp1 - tTmp0;
+                    real tDenom = tA - 2.0 * tB + tC;
+                    tT = clamp01( tNumer / tDenom );
+                    tS = 1.0 - tT;
+                }
+                else
+                {
+                    tS = clamp01( -tD0 / tA );
+                    tT = 0.0;
+                }
+            }
+            else
+            {
+                // Region 1: closest to edge V1-V2
+                real tNumer = ( tC + tD1 ) - ( tB + tD0 );
+                real tDenom = tA - 2.0 * tB + tC;
+                tS          = clamp01( tNumer / tDenom );
+                tT          = 1.0 - tS;
+            }
+        }
+
+        // Compute closest point: P_closest = V0 + s*E0 + t*E1
+        Matrix< DDRMat > tClosest = aV0 + tS * tE0 + tT * tE1;
+
+        // Return distance
+        Matrix< DDRMat > tDiff = aPoint - tClosest;
+        return norm( tDiff );
+    }
+
+    //-------------------------------------------------------------------------------
+
+    real
+    SDF_From_Interface::point_to_segment_distance(
+            const Matrix< DDRMat >& aPoint,
+            const Matrix< DDRMat >& aV0,
+            const Matrix< DDRMat >& aV1 )
+    {
+        Matrix< DDRMat > tEdge = aV1 - aV0;
+        Matrix< DDRMat > tD    = aPoint - aV0;
+
+        real tEdgeLengthSq = dot( tEdge, tEdge );
+
+        // Handle degenerate case (zero-length segment)
+        if ( tEdgeLengthSq < 1.0e-14 )
+        {
+            return norm( tD );
+        }
+
+        // Project point onto line, clamp to segment
+        real tT = clamp01( dot( tD, tEdge ) / tEdgeLengthSq );
+
+        // Closest point on segment
+        Matrix< DDRMat > tClosest = aV0 + tT * tEdge;
+
+        // Return distance
+        Matrix< DDRMat > tDiff = aPoint - tClosest;
+        return norm( tDiff );
+    }
+
+    //-------------------------------------------------------------------------------
+
+    real
+    SDF_From_Interface::clamp01( real aValue )
+    {
+        if ( aValue < 0.0 )
+        {
+            return 0.0;
+        }
+        if ( aValue > 1.0 )
+        {
+            return 1.0;
+        }
+        return aValue;
+    }
+
+    //-------------------------------------------------------------------------------
+
+}    // namespace moris::sdf

--- a/projects/GEN/SDF/src/cl_SDF_From_Interface.hpp
+++ b/projects/GEN/SDF/src/cl_SDF_From_Interface.hpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2022 University of Colorado
+ * Licensed under the MIT license. See LICENSE.txt file in the MORIS root for details.
+ *
+ *------------------------------------------------------------------------------------
+ *
+ * cl_SDF_From_Interface.hpp
+ *
+ */
+
+#pragma once
+
+#include "moris_typedefs.hpp"
+#include "cl_Matrix.hpp"
+#include "linalg_typedefs.hpp"
+#include "cl_Vector.hpp"
+
+namespace moris::sdf
+{
+    //-------------------------------------------------------------------------------
+
+    /**
+     * @brief Computes a signed distance field from interface facet geometry.
+     *
+     * This class provides static methods to compute exact signed distances
+     * from a triangulated interface (in 3D) or segmented interface (in 2D).
+     * It is used for SDF reinitialization during level-set topology optimization
+     * to eliminate floating artifacts and maintain the signed distance property.
+     *
+     * Usage:
+     * @code
+     * Matrix<DDRMat> tSDF;
+     * SDF_From_Interface::compute(
+     *     tMesh,
+     *     tFacetNodeCoords,
+     *     tFacetConnectivity,
+     *     tNodeBulkPhases,
+     *     tMaterialPhaseIndex,
+     *     tSDF);
+     * @endcode
+     */
+    class SDF_From_Interface
+    {
+      public:
+        //-------------------------------------------------------------------------------
+
+        /**
+         * @brief Compute SDF at all mesh nodes from interface facet geometry.
+         *
+         * @param[in]  aNumNodes       Number of nodes in the mesh
+         * @param[in]  aNodeCoords     Node coordinates (NumNodes x SpatialDim)
+         * @param[in]  aFacetNodeCoords Coordinates of facet vertices (NumFacetNodes x SpatialDim)
+         * @param[in]  aFacetConn      Facet connectivity (NumFacets x NodesPerFacet)
+         * @param[in]  aNodeBulkPhase  Bulk phase index for each mesh node
+         * @param[in]  aMaterialPhase  Phase index for "inside" (negative SDF)
+         * @param[out] aSDF            Computed SDF values at mesh nodes (NumNodes x 1)
+         */
+        static void compute(
+                uint                       aNumNodes,
+                const Matrix< DDRMat >&    aNodeCoords,
+                const Matrix< DDRMat >&    aFacetNodeCoords,
+                const Matrix< IndexMat >&  aFacetConn,
+                const Vector< moris_index >& aNodeBulkPhase,
+                moris_index                aMaterialPhase,
+                Matrix< DDRMat >&          aSDF );
+
+        //-------------------------------------------------------------------------------
+
+        /**
+         * @brief Compute signed distance from a point to the nearest interface facet.
+         *
+         * @param[in] aPoint           Point coordinates (SpatialDim x 1)
+         * @param[in] aFacetNodeCoords Coordinates of facet vertices
+         * @param[in] aFacetConn       Facet connectivity
+         * @param[in] aSpatialDim      Spatial dimension (2 or 3)
+         * @return Unsigned distance to nearest facet
+         */
+        static real compute_distance_to_interface(
+                const Matrix< DDRMat >&   aPoint,
+                const Matrix< DDRMat >&   aFacetNodeCoords,
+                const Matrix< IndexMat >& aFacetConn,
+                uint                      aSpatialDim );
+
+        //-------------------------------------------------------------------------------
+
+        /**
+         * @brief Compute distance from a point to a triangle (3D).
+         *
+         * Uses barycentric coordinates to determine the closest point
+         * on the triangle (vertex, edge, or face interior).
+         *
+         * @param[in] aPoint      Point coordinates (3 x 1)
+         * @param[in] aV0, aV1, aV2 Triangle vertex coordinates (3 x 1 each)
+         * @return Distance from point to triangle
+         */
+        static real point_to_triangle_distance(
+                const Matrix< DDRMat >& aPoint,
+                const Matrix< DDRMat >& aV0,
+                const Matrix< DDRMat >& aV1,
+                const Matrix< DDRMat >& aV2 );
+
+        //-------------------------------------------------------------------------------
+
+        /**
+         * @brief Compute distance from a point to a line segment (2D/3D).
+         *
+         * @param[in] aPoint    Point coordinates
+         * @param[in] aV0, aV1  Segment endpoint coordinates
+         * @return Distance from point to segment
+         */
+        static real point_to_segment_distance(
+                const Matrix< DDRMat >& aPoint,
+                const Matrix< DDRMat >& aV0,
+                const Matrix< DDRMat >& aV1 );
+
+        //-------------------------------------------------------------------------------
+
+      private:
+        /**
+         * @brief Clamp a value to [0, 1] range.
+         */
+        static real clamp01( real aValue );
+
+        //-------------------------------------------------------------------------------
+    };
+
+    //-------------------------------------------------------------------------------
+
+}    // namespace moris::sdf

--- a/projects/GEN/SDF/test/CMakeLists.txt
+++ b/projects/GEN/SDF/test/CMakeLists.txt
@@ -11,6 +11,7 @@
 # List source files
 set(TEST_SOURCES
     test_main.cpp
+    ut_SDF_From_Interface.cpp
     ut_SDF_Line.cpp
     ut_SDF_Triangle.cpp 
     ut_SDF_Raycast.cpp

--- a/projects/GEN/SDF/test/ut_SDF_From_Interface.cpp
+++ b/projects/GEN/SDF/test/ut_SDF_From_Interface.cpp
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) 2022 University of Colorado
+ * Licensed under the MIT license. See LICENSE.txt file in the MORIS root for details.
+ *
+ *------------------------------------------------------------------------------------
+ *
+ * ut_SDF_From_Interface.cpp
+ *
+ * Unit tests for SDF_From_Interface class - distance computation from interface facets
+ *
+ */
+
+#include <catch.hpp>
+#include "moris_typedefs.hpp"
+#include "cl_Matrix.hpp"
+#include "linalg_typedefs.hpp"
+#include "fn_norm.hpp"
+#include "cl_Vector.hpp"
+#include "cl_SDF_From_Interface.hpp"
+
+using namespace moris;
+using namespace sdf;
+
+TEST_CASE(
+        "gen::sdf::SDF_From_Interface - Point to Segment",
+        "[geomeng],[sdf],[SDF_From_Interface]" )
+{
+    real tEpsilon = 1e-10;
+
+    //-------------------------------------------------------------------------------
+
+    SECTION( "Point closest to segment midpoint" )
+    {
+        // Segment from (0,0) to (2,0)
+        Matrix< DDRMat > tV0( 2, 1 );
+        Matrix< DDRMat > tV1( 2, 1 );
+        tV0( 0 ) = 0.0; tV0( 1 ) = 0.0;
+        tV1( 0 ) = 2.0; tV1( 1 ) = 0.0;
+
+        // Point at (1, 1) - directly above midpoint
+        Matrix< DDRMat > tPoint( 2, 1 );
+        tPoint( 0 ) = 1.0;
+        tPoint( 1 ) = 1.0;
+
+        real tDist = SDF_From_Interface::point_to_segment_distance( tPoint, tV0, tV1 );
+
+        // Expected distance: 1.0 (straight up from midpoint)
+        REQUIRE( std::abs( tDist - 1.0 ) < tEpsilon );
+    }
+
+    //-------------------------------------------------------------------------------
+
+    SECTION( "Point closest to segment endpoint V0" )
+    {
+        // Segment from (0,0) to (2,0)
+        Matrix< DDRMat > tV0( 2, 1 );
+        Matrix< DDRMat > tV1( 2, 1 );
+        tV0( 0 ) = 0.0; tV0( 1 ) = 0.0;
+        tV1( 0 ) = 2.0; tV1( 1 ) = 0.0;
+
+        // Point at (-1, 0) - past V0
+        Matrix< DDRMat > tPoint( 2, 1 );
+        tPoint( 0 ) = -1.0;
+        tPoint( 1 ) = 0.0;
+
+        real tDist = SDF_From_Interface::point_to_segment_distance( tPoint, tV0, tV1 );
+
+        // Expected distance: 1.0 (distance to V0)
+        REQUIRE( std::abs( tDist - 1.0 ) < tEpsilon );
+    }
+
+    //-------------------------------------------------------------------------------
+
+    SECTION( "Point closest to segment endpoint V1" )
+    {
+        // Segment from (0,0) to (2,0)
+        Matrix< DDRMat > tV0( 2, 1 );
+        Matrix< DDRMat > tV1( 2, 1 );
+        tV0( 0 ) = 0.0; tV0( 1 ) = 0.0;
+        tV1( 0 ) = 2.0; tV1( 1 ) = 0.0;
+
+        // Point at (3, 0) - past V1
+        Matrix< DDRMat > tPoint( 2, 1 );
+        tPoint( 0 ) = 3.0;
+        tPoint( 1 ) = 0.0;
+
+        real tDist = SDF_From_Interface::point_to_segment_distance( tPoint, tV0, tV1 );
+
+        // Expected distance: 1.0 (distance to V1)
+        REQUIRE( std::abs( tDist - 1.0 ) < tEpsilon );
+    }
+
+    //-------------------------------------------------------------------------------
+
+    SECTION( "Point on segment" )
+    {
+        // Segment from (0,0) to (2,0)
+        Matrix< DDRMat > tV0( 2, 1 );
+        Matrix< DDRMat > tV1( 2, 1 );
+        tV0( 0 ) = 0.0; tV0( 1 ) = 0.0;
+        tV1( 0 ) = 2.0; tV1( 1 ) = 0.0;
+
+        // Point at (1, 0) - on segment
+        Matrix< DDRMat > tPoint( 2, 1 );
+        tPoint( 0 ) = 1.0;
+        tPoint( 1 ) = 0.0;
+
+        real tDist = SDF_From_Interface::point_to_segment_distance( tPoint, tV0, tV1 );
+
+        // Expected distance: 0.0
+        REQUIRE( tDist < tEpsilon );
+    }
+}
+
+//-------------------------------------------------------------------------------
+
+TEST_CASE(
+        "gen::sdf::SDF_From_Interface - Point to Triangle",
+        "[geomeng],[sdf],[SDF_From_Interface]" )
+{
+    real tEpsilon = 1e-10;
+
+    // Simple right triangle in xy-plane at z=0
+    // V0 = (0,0,0), V1 = (1,0,0), V2 = (0,1,0)
+    Matrix< DDRMat > tV0( 3, 1 );
+    Matrix< DDRMat > tV1( 3, 1 );
+    Matrix< DDRMat > tV2( 3, 1 );
+
+    tV0( 0 ) = 0.0; tV0( 1 ) = 0.0; tV0( 2 ) = 0.0;
+    tV1( 0 ) = 1.0; tV1( 1 ) = 0.0; tV1( 2 ) = 0.0;
+    tV2( 0 ) = 0.0; tV2( 1 ) = 1.0; tV2( 2 ) = 0.0;
+
+    //-------------------------------------------------------------------------------
+
+    SECTION( "Point directly above triangle interior" )
+    {
+        // Point at (0.25, 0.25, 1.0) - above centroid region
+        Matrix< DDRMat > tPoint( 3, 1 );
+        tPoint( 0 ) = 0.25;
+        tPoint( 1 ) = 0.25;
+        tPoint( 2 ) = 1.0;
+
+        real tDist = SDF_From_Interface::point_to_triangle_distance( tPoint, tV0, tV1, tV2 );
+
+        // Expected distance: 1.0 (straight down to plane)
+        REQUIRE( std::abs( tDist - 1.0 ) < tEpsilon );
+    }
+
+    //-------------------------------------------------------------------------------
+
+    SECTION( "Point directly below triangle interior" )
+    {
+        // Point at (0.25, 0.25, -2.0)
+        Matrix< DDRMat > tPoint( 3, 1 );
+        tPoint( 0 ) = 0.25;
+        tPoint( 1 ) = 0.25;
+        tPoint( 2 ) = -2.0;
+
+        real tDist = SDF_From_Interface::point_to_triangle_distance( tPoint, tV0, tV1, tV2 );
+
+        // Expected distance: 2.0
+        REQUIRE( std::abs( tDist - 2.0 ) < tEpsilon );
+    }
+
+    //-------------------------------------------------------------------------------
+
+    SECTION( "Point closest to vertex V0" )
+    {
+        // Point at (-1, -1, 0) - closest to origin
+        Matrix< DDRMat > tPoint( 3, 1 );
+        tPoint( 0 ) = -1.0;
+        tPoint( 1 ) = -1.0;
+        tPoint( 2 ) = 0.0;
+
+        real tDist = SDF_From_Interface::point_to_triangle_distance( tPoint, tV0, tV1, tV2 );
+
+        // Expected distance: sqrt(2) ≈ 1.414
+        real tExpected = std::sqrt( 2.0 );
+        REQUIRE( std::abs( tDist - tExpected ) < tEpsilon );
+    }
+
+    //-------------------------------------------------------------------------------
+
+    SECTION( "Point closest to edge V0-V1" )
+    {
+        // Point at (0.5, -1, 0) - below edge V0-V1
+        Matrix< DDRMat > tPoint( 3, 1 );
+        tPoint( 0 ) = 0.5;
+        tPoint( 1 ) = -1.0;
+        tPoint( 2 ) = 0.0;
+
+        real tDist = SDF_From_Interface::point_to_triangle_distance( tPoint, tV0, tV1, tV2 );
+
+        // Expected distance: 1.0 (perpendicular to edge)
+        REQUIRE( std::abs( tDist - 1.0 ) < tEpsilon );
+    }
+
+    //-------------------------------------------------------------------------------
+
+    SECTION( "Point on triangle surface" )
+    {
+        // Point at (0.25, 0.25, 0) - on triangle
+        Matrix< DDRMat > tPoint( 3, 1 );
+        tPoint( 0 ) = 0.25;
+        tPoint( 1 ) = 0.25;
+        tPoint( 2 ) = 0.0;
+
+        real tDist = SDF_From_Interface::point_to_triangle_distance( tPoint, tV0, tV1, tV2 );
+
+        // Expected distance: 0.0
+        REQUIRE( tDist < tEpsilon );
+    }
+}
+
+//-------------------------------------------------------------------------------
+
+TEST_CASE(
+        "gen::sdf::SDF_From_Interface - Full SDF Computation 2D",
+        "[geomeng],[sdf],[SDF_From_Interface]" )
+{
+    real tEpsilon = 1e-10;
+
+    // Simple 2D test: unit square with vertical interface at x=0.5
+    // Interface is a vertical line segment from (0.5, 0) to (0.5, 1)
+
+    // Four corner nodes
+    uint tNumNodes = 4;
+    Matrix< DDRMat > tNodeCoords( 4, 2 );
+    tNodeCoords( 0, 0 ) = 0.0; tNodeCoords( 0, 1 ) = 0.0;  // Node 0: (0,0)
+    tNodeCoords( 1, 0 ) = 1.0; tNodeCoords( 1, 1 ) = 0.0;  // Node 1: (1,0)
+    tNodeCoords( 2, 0 ) = 1.0; tNodeCoords( 2, 1 ) = 1.0;  // Node 2: (1,1)
+    tNodeCoords( 3, 0 ) = 0.0; tNodeCoords( 3, 1 ) = 1.0;  // Node 3: (0,1)
+
+    // Interface: single line segment
+    Matrix< DDRMat > tFacetNodeCoords( 2, 2 );
+    tFacetNodeCoords( 0, 0 ) = 0.5; tFacetNodeCoords( 0, 1 ) = 0.0;  // Facet node 0: (0.5, 0)
+    tFacetNodeCoords( 1, 0 ) = 0.5; tFacetNodeCoords( 1, 1 ) = 1.0;  // Facet node 1: (0.5, 1)
+
+    // Connectivity: one segment
+    Matrix< IndexMat > tFacetConn( 1, 2 );
+    tFacetConn( 0, 0 ) = 0;
+    tFacetConn( 0, 1 ) = 1;
+
+    // Bulk phases: left side (x < 0.5) is material (phase 0), right is void (phase 1)
+    Vector< moris_index > tNodeBulkPhase( 4 );
+    tNodeBulkPhase( 0 ) = 0;  // Node at x=0 is material
+    tNodeBulkPhase( 1 ) = 1;  // Node at x=1 is void
+    tNodeBulkPhase( 2 ) = 1;  // Node at x=1 is void
+    tNodeBulkPhase( 3 ) = 0;  // Node at x=0 is material
+
+    moris_index tMaterialPhase = 0;
+
+    // Compute SDF
+    Matrix< DDRMat > tSDF;
+    SDF_From_Interface::compute(
+            tNumNodes,
+            tNodeCoords,
+            tFacetNodeCoords,
+            tFacetConn,
+            tNodeBulkPhase,
+            tMaterialPhase,
+            tSDF );
+
+    //-------------------------------------------------------------------------------
+
+    SECTION( "Verify SDF values at corners" )
+    {
+        // Node 0 at (0,0): material, distance = 0.5, SDF = -0.5
+        REQUIRE( std::abs( tSDF( 0 ) - ( -0.5 ) ) < tEpsilon );
+
+        // Node 1 at (1,0): void, distance = 0.5, SDF = +0.5
+        REQUIRE( std::abs( tSDF( 1 ) - 0.5 ) < tEpsilon );
+
+        // Node 2 at (1,1): void, distance = 0.5, SDF = +0.5
+        REQUIRE( std::abs( tSDF( 2 ) - 0.5 ) < tEpsilon );
+
+        // Node 3 at (0,1): material, distance = 0.5, SDF = -0.5
+        REQUIRE( std::abs( tSDF( 3 ) - ( -0.5 ) ) < tEpsilon );
+    }
+
+    //-------------------------------------------------------------------------------
+
+    SECTION( "Verify sign convention" )
+    {
+        // Material nodes have negative SDF
+        REQUIRE( tSDF( 0 ) < 0.0 );
+        REQUIRE( tSDF( 3 ) < 0.0 );
+
+        // Void nodes have positive SDF
+        REQUIRE( tSDF( 1 ) > 0.0 );
+        REQUIRE( tSDF( 2 ) > 0.0 );
+    }
+}
+
+//-------------------------------------------------------------------------------
+
+TEST_CASE(
+        "gen::sdf::SDF_From_Interface - Circle Interface",
+        "[geomeng],[sdf],[SDF_From_Interface]" )
+{
+    // Approximate a circle of radius R=0.5 centered at (0.5, 0.5, 0)
+    // using a regular polygon with N segments
+
+    real tRadius = 0.5;
+    real tCenterX = 0.5;
+    real tCenterY = 0.5;
+    uint tNumSegments = 32;
+
+    // Create facet vertices on circle
+    Matrix< DDRMat > tFacetNodeCoords( tNumSegments, 2 );
+    for ( uint i = 0; i < tNumSegments; ++i )
+    {
+        real tTheta = 2.0 * M_PI * (real)i / (real)tNumSegments;
+        tFacetNodeCoords( i, 0 ) = tCenterX + tRadius * std::cos( tTheta );
+        tFacetNodeCoords( i, 1 ) = tCenterY + tRadius * std::sin( tTheta );
+    }
+
+    // Connectivity: closed polygon
+    Matrix< IndexMat > tFacetConn( tNumSegments, 2 );
+    for ( uint i = 0; i < tNumSegments; ++i )
+    {
+        tFacetConn( i, 0 ) = i;
+        tFacetConn( i, 1 ) = ( i + 1 ) % tNumSegments;
+    }
+
+    // Test points: center, on circle, and outside
+    uint tNumNodes = 4;
+    Matrix< DDRMat > tNodeCoords( 4, 2 );
+    tNodeCoords( 0, 0 ) = 0.5; tNodeCoords( 0, 1 ) = 0.5;   // Center
+    tNodeCoords( 1, 0 ) = 0.5; tNodeCoords( 1, 1 ) = 0.0;   // On boundary (south)
+    tNodeCoords( 2, 0 ) = 0.5; tNodeCoords( 2, 1 ) = 1.5;   // Outside (north)
+    tNodeCoords( 3, 0 ) = 0.0; tNodeCoords( 3, 1 ) = 0.0;   // Outside (corner)
+
+    Vector< moris_index > tNodeBulkPhase( 4 );
+    tNodeBulkPhase( 0 ) = 0;  // Inside
+    tNodeBulkPhase( 1 ) = 0;  // On boundary (treat as inside)
+    tNodeBulkPhase( 2 ) = 1;  // Outside
+    tNodeBulkPhase( 3 ) = 1;  // Outside
+
+    Matrix< DDRMat > tSDF;
+    SDF_From_Interface::compute( tNumNodes, tNodeCoords, tFacetNodeCoords, tFacetConn, tNodeBulkPhase, 0, tSDF );
+
+    //-------------------------------------------------------------------------------
+
+    SECTION( "Center point SDF approximately -R" )
+    {
+        // Center should have SDF ≈ -R = -0.5 (negative because inside)
+        // Polygon approximation introduces small error
+        real tExpected = -tRadius;
+        real tTolerance = 0.01;  // 1% tolerance for polygon approximation
+        REQUIRE( std::abs( tSDF( 0 ) - tExpected ) < tTolerance );
+    }
+
+    //-------------------------------------------------------------------------------
+
+    SECTION( "Point on boundary has SDF near zero" )
+    {
+        // Point at (0.5, 0) is at distance 0 from circle
+        real tTolerance = 0.02;  // Polygon approximation
+        REQUIRE( std::abs( tSDF( 1 ) ) < tTolerance );
+    }
+
+    //-------------------------------------------------------------------------------
+
+    SECTION( "Outside point has positive SDF" )
+    {
+        // Point at (0.5, 1.5) is distance 0.5 from boundary (outside)
+        real tExpected = 0.5;  // Distance from (0.5, 1.5) to (0.5, 1.0)
+        real tTolerance = 0.02;
+        REQUIRE( std::abs( tSDF( 2 ) - tExpected ) < tTolerance );
+    }
+}

--- a/projects/GEN/SDF/test/ut_SDF_From_Interface.cpp
+++ b/projects/GEN/SDF/test/ut_SDF_From_Interface.cpp
@@ -370,3 +370,263 @@ TEST_CASE(
         REQUIRE( std::abs( tSDF( 2 ) - tExpected ) < tTolerance );
     }
 }
+
+//-------------------------------------------------------------------------------
+
+TEST_CASE(
+        "gen::sdf::SDF_From_Interface - 3D Icosphere Interface",
+        "[geomeng],[sdf],[SDF_From_Interface]" )
+{
+    // Approximate a sphere of radius R=1.0 centered at origin
+    // using an icosphere (triangulated sphere)
+
+    real tRadius = 1.0;
+
+    // Create icosphere vertices (12 vertices of regular icosahedron)
+    real tPhi = ( 1.0 + std::sqrt( 5.0 ) ) / 2.0;  // Golden ratio
+    real tNorm = std::sqrt( 1.0 + tPhi * tPhi );
+
+    // Normalized icosahedron vertices scaled to radius
+    Matrix< DDRMat > tFacetNodeCoords( 12, 3 );
+
+    // Vertices on unit icosahedron, scaled to radius
+    uint k = 0;
+    for ( int i = -1; i <= 1; i += 2 )
+    {
+        for ( int j = -1; j <= 1; j += 2 )
+        {
+            tFacetNodeCoords( k, 0 ) = 0.0;
+            tFacetNodeCoords( k, 1 ) = tRadius * (real)i / tNorm;
+            tFacetNodeCoords( k, 2 ) = tRadius * tPhi * (real)j / tNorm;
+            ++k;
+        }
+    }
+    for ( int i = -1; i <= 1; i += 2 )
+    {
+        for ( int j = -1; j <= 1; j += 2 )
+        {
+            tFacetNodeCoords( k, 0 ) = tRadius * (real)i / tNorm;
+            tFacetNodeCoords( k, 1 ) = tRadius * tPhi * (real)j / tNorm;
+            tFacetNodeCoords( k, 2 ) = 0.0;
+            ++k;
+        }
+    }
+    for ( int i = -1; i <= 1; i += 2 )
+    {
+        for ( int j = -1; j <= 1; j += 2 )
+        {
+            tFacetNodeCoords( k, 0 ) = tRadius * tPhi * (real)i / tNorm;
+            tFacetNodeCoords( k, 1 ) = 0.0;
+            tFacetNodeCoords( k, 2 ) = tRadius * (real)j / tNorm;
+            ++k;
+        }
+    }
+
+    // 20 triangular faces of icosahedron
+    Matrix< IndexMat > tFacetConn( 20, 3 );
+    // Face connectivity for icosahedron (manually specified)
+    moris_index tFaces[20][3] = {
+        {0, 11, 5}, {0, 5, 1}, {0, 1, 7}, {0, 7, 10}, {0, 10, 11},
+        {1, 5, 9}, {5, 11, 4}, {11, 10, 2}, {10, 7, 6}, {7, 1, 8},
+        {3, 9, 4}, {3, 4, 2}, {3, 2, 6}, {3, 6, 8}, {3, 8, 9},
+        {4, 9, 5}, {2, 4, 11}, {6, 2, 10}, {8, 6, 7}, {9, 8, 1}
+    };
+    for ( uint i = 0; i < 20; ++i )
+    {
+        for ( uint j = 0; j < 3; ++j )
+        {
+            tFacetConn( i, j ) = tFaces[i][j];
+        }
+    }
+
+    // Test nodes: center, on sphere surface, inside, outside
+    uint tNumNodes = 5;
+    Matrix< DDRMat > tNodeCoords( 5, 3 );
+    tNodeCoords( 0, 0 ) = 0.0; tNodeCoords( 0, 1 ) = 0.0; tNodeCoords( 0, 2 ) = 0.0;    // Center
+    tNodeCoords( 1, 0 ) = 1.0; tNodeCoords( 1, 1 ) = 0.0; tNodeCoords( 1, 2 ) = 0.0;    // On surface (+x)
+    tNodeCoords( 2, 0 ) = 0.0; tNodeCoords( 2, 1 ) = 0.5; tNodeCoords( 2, 2 ) = 0.0;    // Inside (r=0.5)
+    tNodeCoords( 3, 0 ) = 0.0; tNodeCoords( 3, 1 ) = 0.0; tNodeCoords( 3, 2 ) = 2.0;    // Outside (r=2.0)
+    tNodeCoords( 4, 0 ) = 0.0; tNodeCoords( 4, 1 ) = -1.5; tNodeCoords( 4, 2 ) = 0.0;   // Outside (-y)
+
+    Vector< moris_index > tNodeBulkPhase( 5 );
+    tNodeBulkPhase( 0 ) = 0;  // Inside
+    tNodeBulkPhase( 1 ) = 0;  // On boundary (treat as inside)
+    tNodeBulkPhase( 2 ) = 0;  // Inside
+    tNodeBulkPhase( 3 ) = 1;  // Outside
+    tNodeBulkPhase( 4 ) = 1;  // Outside
+
+    Matrix< DDRMat > tSDF;
+    SDF_From_Interface::compute( tNumNodes, tNodeCoords, tFacetNodeCoords, tFacetConn, tNodeBulkPhase, 0, tSDF );
+
+    // Tolerance for icosahedron approximation error
+    // Note: Icosahedron is a very coarse sphere approximation (only 20 faces)
+    // The inscribed radius is ~0.795*R but circumscribed is R, causing significant error
+    real tTolerance = 0.9;  // Large tolerance due to coarse icosahedron (~20% error typical)
+
+    //-------------------------------------------------------------------------------
+
+    SECTION( "Center point SDF approximately -R" )
+    {
+        // Center should have SDF ≈ -R = -1.0 (negative because inside)
+        real tExpected = -tRadius;
+        REQUIRE( std::abs( tSDF( 0 ) - tExpected ) < tTolerance );
+    }
+
+    //-------------------------------------------------------------------------------
+
+    SECTION( "Point on surface has SDF near zero" )
+    {
+        // Point at (1,0,0) should be on surface, SDF ≈ 0
+        REQUIRE( std::abs( tSDF( 1 ) ) < tTolerance );
+    }
+
+    //-------------------------------------------------------------------------------
+
+    SECTION( "Inside point has negative SDF" )
+    {
+        // Point at (0, 0.5, 0) is inside, SDF ≈ -0.5
+        real tExpected = -0.5;
+        REQUIRE( std::abs( tSDF( 2 ) - tExpected ) < tTolerance );
+    }
+
+    //-------------------------------------------------------------------------------
+
+    SECTION( "Outside points have positive SDF" )
+    {
+        // Point at (0, 0, 2) is outside, SDF ≈ +1.0
+        real tExpected = 1.0;
+        REQUIRE( std::abs( tSDF( 3 ) - tExpected ) < tTolerance );
+
+        // Point at (0, -1.5, 0) is outside, SDF ≈ +0.5
+        tExpected = 0.5;
+        REQUIRE( std::abs( tSDF( 4 ) - tExpected ) < tTolerance );
+    }
+}
+
+//-------------------------------------------------------------------------------
+
+TEST_CASE(
+        "gen::sdf::SDF_From_Interface - Gradient Magnitude Verification",
+        "[geomeng],[sdf],[SDF_From_Interface],[gradient]" )
+{
+    // KEY SUCCESS CRITERION:
+    // For a true SDF, |∇φ| = 1 everywhere (except at interface)
+    // We verify this using finite differences on a regular grid
+
+    // 2D test with vertical interface at x = 0.5
+    real tInterfaceX = 0.5;
+
+    // Create a regular grid of test points
+    uint tNx = 11;  // Points in x
+    uint tNy = 5;   // Points in y
+    real tDx = 0.1; // Grid spacing
+
+    uint tNumNodes = tNx * tNy;
+    Matrix< DDRMat > tNodeCoords( tNumNodes, 2 );
+
+    for ( uint iy = 0; iy < tNy; ++iy )
+    {
+        for ( uint ix = 0; ix < tNx; ++ix )
+        {
+            uint idx = iy * tNx + ix;
+            tNodeCoords( idx, 0 ) = (real)ix * tDx;
+            tNodeCoords( idx, 1 ) = 0.25 + (real)iy * tDx;  // Offset to avoid boundary
+        }
+    }
+
+    // Simple vertical interface
+    Matrix< DDRMat > tFacetNodeCoords( 2, 2 );
+    tFacetNodeCoords( 0, 0 ) = tInterfaceX; tFacetNodeCoords( 0, 1 ) = 0.0;
+    tFacetNodeCoords( 1, 0 ) = tInterfaceX; tFacetNodeCoords( 1, 1 ) = 1.0;
+
+    Matrix< IndexMat > tFacetConn( 1, 2 );
+    tFacetConn( 0, 0 ) = 0;
+    tFacetConn( 0, 1 ) = 1;
+
+    // Bulk phases: left is material (0), right is void (1)
+    Vector< moris_index > tNodeBulkPhase( tNumNodes );
+    for ( uint i = 0; i < tNumNodes; ++i )
+    {
+        tNodeBulkPhase( i ) = ( tNodeCoords( i, 0 ) < tInterfaceX ) ? 0 : 1;
+    }
+
+    // Compute SDF
+    Matrix< DDRMat > tSDF;
+    SDF_From_Interface::compute( tNumNodes, tNodeCoords, tFacetNodeCoords, tFacetConn, tNodeBulkPhase, 0, tSDF );
+
+    //-------------------------------------------------------------------------------
+
+    SECTION( "Gradient magnitude is approximately 1.0 (SDF property)" )
+    {
+        // Use central differences to compute gradient magnitude
+        // Skip boundary nodes and nodes too close to interface
+
+        real tMaxDeviation = 0.0;
+        uint tTestedPoints = 0;
+
+        for ( uint iy = 1; iy < tNy - 1; ++iy )
+        {
+            for ( uint ix = 1; ix < tNx - 1; ++ix )
+            {
+                uint idx = iy * tNx + ix;
+                real tX = tNodeCoords( idx, 0 );
+
+                // Skip points very close to interface (gradient undefined there)
+                if ( std::abs( tX - tInterfaceX ) < 1.5 * tDx )
+                {
+                    continue;
+                }
+
+                // Central difference for dφ/dx
+                real tPhi_xp = tSDF( idx + 1 );           // φ(x+h, y)
+                real tPhi_xm = tSDF( idx - 1 );           // φ(x-h, y)
+                real tDPhiDx = ( tPhi_xp - tPhi_xm ) / ( 2.0 * tDx );
+
+                // Central difference for dφ/dy
+                real tPhi_yp = tSDF( idx + tNx );         // φ(x, y+h)
+                real tPhi_ym = tSDF( idx - tNx );         // φ(x, y-h)
+                real tDPhiDy = ( tPhi_yp - tPhi_ym ) / ( 2.0 * tDx );
+
+                // Gradient magnitude
+                real tGradMag = std::sqrt( tDPhiDx * tDPhiDx + tDPhiDy * tDPhiDy );
+
+                // Track maximum deviation from 1.0
+                real tDeviation = std::abs( tGradMag - 1.0 );
+                tMaxDeviation = std::max( tMaxDeviation, tDeviation );
+                ++tTestedPoints;
+            }
+        }
+
+        // Report results
+        INFO( "Max gradient magnitude deviation from 1.0: " << tMaxDeviation );
+        INFO( "Number of tested interior points: " << tTestedPoints );
+
+        // SUCCESS CRITERION: |∇φ| - 1 < 0.05 (5% tolerance)
+        REQUIRE( tTestedPoints > 0 );
+        REQUIRE( tMaxDeviation < 0.05 );
+    }
+
+    //-------------------------------------------------------------------------------
+
+    SECTION( "SDF values match analytic solution" )
+    {
+        // For vertical interface at x = 0.5, analytic SDF is:
+        // φ(x) = x - 0.5 for void (x > 0.5)
+        // φ(x) = 0.5 - x for material (x < 0.5), with sign flip → -(0.5 - x) = x - 0.5
+        // Wait, our convention: material = negative, void = positive
+        // So: φ = -(0.5 - x) = x - 0.5 for material, φ = x - 0.5 for void
+        // Actually: material: φ = -(distance) = -(0.5 - x) for x < 0.5
+        //           void:     φ = +(distance) = +(x - 0.5) for x > 0.5
+
+        real tTolerance = 1e-10;
+
+        for ( uint i = 0; i < tNumNodes; ++i )
+        {
+            real tX = tNodeCoords( i, 0 );
+            real tDistance = std::abs( tX - tInterfaceX );
+            real tExpectedSDF = ( tX < tInterfaceX ) ? -tDistance : tDistance;
+
+            REQUIRE( std::abs( tSDF( i ) - tExpectedSDF ) < tTolerance );
+        }
+    }
+}

--- a/projects/MRS/CHR/src/cl_Profiler.hpp
+++ b/projects/MRS/CHR/src/cl_Profiler.hpp
@@ -111,21 +111,27 @@ namespace moris
             // get path to moris executable
             const std::string& tExec = gMorisComm.get_exec_path();
 
-            // get app path
-            std::string tApps = getenv( "APPS" );
-
-            MORIS_ERROR( tApps.size() > 0,
-                    "Environment variable APPS not set." );
+            // locate the pprof tool: prefer $APPS/gperftools/bin/pprof, otherwise fall
+            // back to "google-pprof" (the name used by the system gperftools package)
+            const char* tAppsEnv = getenv( "APPS" );
+            std::string tPprof   = ( tAppsEnv != nullptr && std::string( tAppsEnv ).size() > 0 )
+                                         ? std::string( tAppsEnv ) + "/gperftools/bin/pprof"
+                                         : "google-pprof";
 
             // assemble command line
-            std::string tCommand = tApps + "/gperftools/bin/pprof --callgrind "
+            std::string tCommand = tPprof + " --callgrind "
                                  + tExec + " " + mLogFile + " > " + mCallgrindFile;
 
             // fixme: replace this line with moris logger
             std::cout << "Creating callgrind file " << mCallgrindFile << " ..." << std::endl;
 
             // convert logfile to callgrind
-            system( tCommand.c_str() );
+            int tSysRet = system( tCommand.c_str() );
+            if ( tSysRet != 0 )
+            {
+                std::cerr << "MORIS Profiler: callgrind conversion failed (exit "
+                          << tSysRet << "). Command: " << tCommand << std::endl;
+            }
 
             // fixme: replace this line with moris logger
             std::cout << "... Stopped MORIS Profiler" << std::endl;

--- a/projects/MRS/IOS/doc/Performance_Report.md
+++ b/projects/MRS/IOS/doc/Performance_Report.md
@@ -1,0 +1,125 @@
+# Run Performance Report
+
+A consolidated end-of-run report of **where a MORIS run spent its time and memory**, broken
+down per module. It reuses the existing tracer instrumentation (`Tracer` / `GlobalClock` /
+`Logger`), so no new instrumentation is added at call sites — the report is a passive consumer of
+the sign-in / sign-out events MORIS already emits at every module boundary (HMR, XTK, GEN, MDL,
+SOL, …).
+
+Two artifacts are produced at the end of a run:
+
+1. A **console summary table** (printed via the logger, rank 0).
+2. A **JSON report** written by rank 0 to `performance_report_file` (default `perf_report.json`),
+   relative to the working directory the run was launched from.
+
+## Quick start
+
+```bash
+# bare moris binary
+moris input.so --perf-level 2                     # per-module table + JSON
+moris input.so --perf-level 3 --perf-report run.json
+
+# via an environment variable (works for any entry point, e.g. EXA example executables
+# that do not forward CLI flags)
+MORIS_PERF_LEVEL=3 ./Main_Two_Bar_Truss.exe
+```
+
+## Configuration
+
+The granularity level and output path are resolved in this order (last wins):
+
+1. OPT parameter list: `performance_report_level` (int, default `1`) and
+   `performance_report_file` (string, default `"perf_report.json"`), declared in
+   `prm::create_opt_problem_parameter_list()`.
+2. Environment variable `MORIS_PERF_LEVEL`.
+3. CLI flags `--perf-level N` and `--perf-report <path>`.
+
+A negative level disables the report. Decks that predate these parameters still run unchanged —
+the reader guards every lookup with `exists()`.
+
+### Granularity levels
+
+| Level | Contents |
+|-------|----------|
+| `0` | Run total only — total wall time + peak memory. |
+| `1` | Top-level modules (depth ≤ 2): HMR, XTK, GEN, MDL, … one row each. |
+| `2` | Modules + nested sub-regions (depth ≤ 4): MDL forward/sensitivity, the solver stack, … |
+| `3` | Full nested tracer tree (every region), plus an optional gperftools CPU callgrind profile. |
+
+## Output
+
+### Console table
+
+```
+==================== MORIS Performance Report (level 1) ====================
+Module (entity - action)               Visits     Wall[s]      Wall max/min     MemD[MB]    MemDpeak
+-------------------------------------------------------------------------------------------------------
+OPT - Perform                               1       1.341         1.34/1.34          4.0         4.0
+MDL - Perform Forward Analysis              2       0.003         0.00/0.00          0.2         0.2
+...
+-------------------------------------------------------------------------------------------------------
+Run total wall (max over ranks): 1.349 s   |   Peak memory (max over ranks): 12.8 MB [tcmalloc]
+```
+
+Rows are summed over every visit to a region (so timings accumulate across optimization
+iterations) and sorted by wall time. `Wall max/min` are reductions across MPI ranks. The
+`MemD[MB]` (growth) column is clamped at zero; the raw signed delta is kept in the JSON.
+
+### JSON schema
+
+```json
+{
+  "level": 1,
+  "run_total_wall_s": 1.349,
+  "peak_mem_mb": 12.82,
+  "mem_source": "tcmalloc",        // or "proc_rss"
+  "ranks_aligned": true,
+  "modules": [
+    {
+      "entity": "OPT", "type": "Manager", "action": "Perform",
+      "depth": 1, "visits": 1,
+      "wall_s": 1.341, "wall_s_max": 1.341, "wall_s_min": 1.341,
+      "mem_delta_mb": 4.03, "mem_delta_peak_mb": 4.03
+    }
+  ]
+}
+```
+
+## Memory source
+
+`Logger::current_memory_mb()` provides the numbers:
+
+- **With gperftools** (`MORIS_USE_GPERFTOOLS=ON`): tcmalloc's
+  `generic.current_allocated_bytes` via `MallocExtension`. `mem_source` reports `tcmalloc`.
+- **Otherwise**: physical resident set size from `/proc/self/statm`. `mem_source` reports
+  `proc_rss`.
+
+Per-module values are the **change** in this metric across a region; the run-level peak is the
+high-water mark sampled at every boundary. RSS deltas can be negative (allocator page returns) —
+that is why the console growth column is clamped while the JSON keeps the raw value.
+
+## gperftools
+
+Building with `-DMORIS_USE_GPERFTOOLS=ON` (which defines `WITHGPERFTOOLS`, links `-ltcmalloc
+-lprofiler`, and needs the system `libgoogle-perftools-dev` package) enables two things:
+
+- tcmalloc-sourced memory numbers (above).
+- At `--perf-level 3`, the whole run is wrapped in `moris::Profiler`, which emits a callgrind CPU
+  profile via `pprof` (falls back to the system `google-pprof` when `$APPS/gperftools/bin/pprof`
+  is absent).
+
+Without gperftools, the report still produces the full time + memory summary via the `/proc`
+fallback — only the deep CPU profile is unavailable.
+
+## Implementation
+
+| File | Role |
+|------|------|
+| `cl_Performance_Reporter.{hpp,cpp}` | Accumulator + MPI aggregation + console table + JSON writer; global `gPerfReporter`. |
+| `cl_Logger.cpp` | `current_memory_mb()`; `sign_in`/`sign_out` feed `gPerfReporter.record_region` / `update_peak_rss`. |
+| `cl_GlobalClock.{hpp,cpp}` | `mMemoryStamps` — per-region sign-in memory snapshot. |
+| `fn_WRK_Workflow_Main_Interface.cpp` | Resolves the level/path config and calls `initialize()`; optional gperftools CPU profile. |
+| `main.cpp`, `EXA/src/example_main.cpp` | Call `gPerfReporter.finalize()` before MPI finalize. |
+| `fn_PRM_OPT_Parameters.hpp` | `performance_report_level` / `performance_report_file` defaults. |
+
+Unit test: `projects/MRS/IOS/test/UT_IOS_Performance_Reporter.cpp`.

--- a/projects/MRS/IOS/src/CMakeLists.txt
+++ b/projects/MRS/IOS/src/CMakeLists.txt
@@ -34,6 +34,7 @@ set(HEADERS
         ios.hpp
         Log_Constants.hpp
         cl_Json_Object.hpp
+        cl_Performance_Reporter.hpp
 )
 
 # List library source files
@@ -54,6 +55,7 @@ set(LIB_SOURCES
         cl_Ascii.cpp
         fn_Parsing_Tools.cpp
         cl_Json_Object.cpp
+        cl_Performance_Reporter.cpp
 )
 
 

--- a/projects/MRS/IOS/src/cl_GlobalClock.cpp
+++ b/projects/MRS/IOS/src/cl_GlobalClock.cpp
@@ -50,6 +50,9 @@ namespace moris
         // record starting time
         mTimeStamps.resize( 1, (real)std::clock() );
 
+        // record starting memory usage
+        mMemoryStamps.resize( 1, 0.0 );
+
         // record action data for new entry
         mActionData.resize( 1, std::unordered_map< std::string, real >() );
 
@@ -64,7 +67,8 @@ namespace moris
     GlobalClock::sign_in(
             const std::string& aEntityBase,
             const std::string& aEntityType,
-            const std::string& aEntityAction )
+            const std::string& aEntityAction,
+            real               aMemoryNowMb )
     {
         // increment indentation level
         mIndentationLevel++;
@@ -93,6 +97,9 @@ namespace moris
         // create time stamp for new entity
         mTimeStamps.push_back( (real)std::clock() );
 
+        // record memory usage at sign-in for new entity
+        mMemoryStamps.push_back( aMemoryNowMb );
+
         // create map for action data for new entry
         mActionData.push_back( std::unordered_map< std::string, real >() );
 
@@ -117,6 +124,9 @@ namespace moris
     {
         // remove time stamp from list of active entities
         mTimeStamps.pop_back();
+
+        // remove memory stamp from list of active entities
+        mMemoryStamps.pop_back();
 
         // remove iteration time stamp from list of active entities
         mIterationTimeStamps.pop_back();

--- a/projects/MRS/IOS/src/cl_GlobalClock.hpp
+++ b/projects/MRS/IOS/src/cl_GlobalClock.hpp
@@ -58,6 +58,9 @@ namespace moris
         // list of starting times for each active entity
         std::vector< real > mTimeStamps;
 
+        // list of memory usage (MB) sampled when each active entity signed in
+        std::vector< real > mMemoryStamps;
+
         // list of maps for action data for each active entry
         std::vector< std::unordered_map< std::string, real > > mActionData;
 
@@ -87,11 +90,14 @@ namespace moris
          * @param aEntityBase Entity base
          * @param aEntityType Entity type
          * @param aEntityAction Entity action
+         * @param aMemoryNowMb Current process memory usage [MB] (supplied by the
+         *                     Logger, which owns the memory sampler)
          */
         void sign_in(
                 const std::string& aEntityBase,
                 const std::string& aEntityType,
-                const std::string& aEntityAction );
+                const std::string& aEntityAction,
+                real               aMemoryNowMb = 0.0 );
 
         // --------------------------------------------------------------------------------
         // operation to stop tracing an entity, decrement all lists

--- a/projects/MRS/IOS/src/cl_Logger.cpp
+++ b/projects/MRS/IOS/src/cl_Logger.cpp
@@ -35,6 +35,11 @@
 #include "Log_Constants.hpp"
 #include "cl_Git_info.hpp"
 #include "cl_Communication_Tools.hpp"
+#include "cl_Performance_Reporter.hpp"
+
+#ifdef WITHGPERFTOOLS
+#include <gperftools/malloc_extension.h>
+#endif
 
 namespace moris
 {
@@ -129,8 +134,14 @@ namespace moris
             const std::string& aEntityType,
             const std::string& aEntityAction )
     {
+        // sample current memory usage and feed the global clock + performance reporter
+        real tMemoryNowMb = this->current_memory_mb();
+
         // pass save info to clock
-        mGlobalClock.sign_in( aEntityBase, aEntityType, aEntityAction );
+        mGlobalClock.sign_in( aEntityBase, aEntityType, aEntityAction, tMemoryNowMb );
+
+        // track run-level peak memory
+        gPerfReporter.update_peak_rss( tMemoryNowMb );
 
         // log to file
         if ( mWriteToAscii )
@@ -296,6 +307,34 @@ namespace moris
             }    // end if: sufficient output severity
 
         }    // end if: current proc is output rank
+
+        // feed the consolidated performance reporter before the clock pops this entity
+        if ( gPerfReporter.is_enabled() )
+        {
+            const uint tLevel = mGlobalClock.mIndentationLevel;
+
+            // prefer wall time for the per-module report; fall back to CPU time
+            real tRegionTime = tElapsedTime;
+            if ( PRINT_WALL_TIME )
+            {
+                std::chrono::duration< double > tRegionWall =
+                        ( std::chrono::system_clock::now() - mGlobalClock.mWallTimeStamps[ tLevel ] );
+                tRegionTime = tRegionWall.count();
+            }
+
+            real tMemoryNowMb = this->current_memory_mb();
+            real tMemoryDelta = tMemoryNowMb - mGlobalClock.mMemoryStamps[ tLevel ];
+
+            gPerfReporter.record_region(
+                    mGlobalClock.mCurrentEntity[ tLevel ],
+                    mGlobalClock.mCurrentType[ tLevel ],
+                    mGlobalClock.mCurrentAction[ tLevel ],
+                    tLevel,
+                    tRegionTime,
+                    tMemoryDelta );
+
+            gPerfReporter.update_peak_rss( tMemoryNowMb );
+        }
 
         // decrement clock
         mGlobalClock.sign_out();
@@ -810,5 +849,28 @@ namespace moris
                      " | min " + std::to_string( tMinUsage );
 
         return tMemUsage;
+    }
+
+    // -----------------------------------------------------------------------------
+
+    // current process memory usage [MB] as a number
+    real
+    Logger::current_memory_mb()
+    {
+#ifdef WITHGPERFTOOLS
+        // heap bytes currently handed out by tcmalloc (the active allocator)
+        size_t tBytes = 0;
+        if ( MallocExtension::instance()->GetNumericProperty( "generic.current_allocated_bytes", &tBytes ) )
+        {
+            return tBytes / 1024.0 / 1024.0;
+        }
+#endif
+        // fallback: physical resident set size from /proc (same source as memory_usage())
+        std::ifstream statm( "/proc/self/statm" );
+        unsigned long vmem_size = 0;
+        unsigned long phys_size = 0;
+        statm >> vmem_size >> phys_size;
+
+        return phys_size * (size_t)sysconf( _SC_PAGESIZE ) / 1024.0 / 1024.0;
     }
 }    // end namespace moris

--- a/projects/MRS/IOS/src/cl_Logger.hpp
+++ b/projects/MRS/IOS/src/cl_Logger.hpp
@@ -616,6 +616,12 @@ namespace moris
 
         //------------------------------------------------------------------------------
 
+        // current process memory usage [MB] as a number; uses tcmalloc's allocated-bytes
+        // counter when MORIS is built with gperftools, otherwise physical RSS from /proc
+        real current_memory_mb();
+
+        //------------------------------------------------------------------------------
+
         // write logged info to formatted file
         template< class T >
         void

--- a/projects/MRS/IOS/src/cl_Performance_Reporter.cpp
+++ b/projects/MRS/IOS/src/cl_Performance_Reporter.cpp
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2022 University of Colorado
+ * Licensed under the MIT license. See LICENSE.txt file in the MORIS root for details.
+ *
+ *------------------------------------------------------------------------------------
+ *
+ * cl_Performance_Reporter.cpp
+ *
+ */
+
+#include "cl_Performance_Reporter.hpp"
+
+#include <algorithm>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+#include <mpi.h>
+
+#include "cl_Communication_Tools.hpp"    // COM/src   (par_rank, par_size)
+#include "cl_Json_Object.hpp"            // MRS/IOS/src
+#include "cl_Logger.hpp"                 // MRS/IOS/src (MORIS_LOG)
+
+// global instance - defined here so any executable linking IOS gets it
+moris::Performance_Reporter gPerfReporter;
+
+namespace moris
+{
+    //------------------------------------------------------------------------------
+
+    namespace
+    {
+        // collective reduction of a single scalar across all ranks
+        real
+        reduce_all( real aLocal, MPI_Op aOp )
+        {
+            real tGlobal = aLocal;
+            MPI_Allreduce( &aLocal, &tGlobal, 1, MPI_DOUBLE, aOp, MPI_COMM_WORLD );
+            return tGlobal;
+        }
+
+        // display row pairing an accumulated record with its cross-rank wall stats
+        struct Display_Row
+        {
+            Module_Performance_Record mRecord;
+            real                      mWallMax = 0.0;
+            real                      mWallMin = 0.0;
+        };
+    }    // namespace
+
+    //------------------------------------------------------------------------------
+
+    void
+    Performance_Reporter::initialize( sint aLevel, const std::string& aJsonPath )
+    {
+        mEnabled  = true;
+        mLevel    = std::min< sint >( std::max< sint >( aLevel, 0 ), 3 );
+        mJsonPath = aJsonPath;
+
+        // mark the source of the memory numbers reported (see Logger::current_memory_mb)
+#ifdef WITHGPERFTOOLS
+        mMemSource = "tcmalloc";
+#else
+        mMemSource = "proc_rss";
+#endif
+
+        mRunWallStart = std::chrono::system_clock::now();
+    }
+
+    //------------------------------------------------------------------------------
+
+    bool
+    Performance_Reporter::include_in_report( uint aDepth ) const
+    {
+        switch ( mLevel )
+        {
+            case 0:
+                return false;
+            case 1:
+                return aDepth <= 2;
+            case 2:
+                return aDepth <= 4;
+            default:
+                return true;
+        }
+    }
+
+    //------------------------------------------------------------------------------
+
+    void
+    Performance_Reporter::record_region(
+            const std::string& aEntity,
+            const std::string& aType,
+            const std::string& aAction,
+            uint               aDepth,
+            real               aWallSeconds,
+            real               aMemDeltaMb )
+    {
+        // nothing to accumulate when disabled or only run totals are requested
+        if ( !mEnabled || mLevel <= 0 )
+        {
+            return;
+        }
+
+        const std::string tKey = aEntity + "|" + aType + "|" + aAction;
+
+        Module_Performance_Record& tRec = mRecords[ tKey ];
+
+        // initialize identifying fields on first visit
+        if ( tRec.mVisitCount == 0 )
+        {
+            tRec.mEntity = aEntity;
+            tRec.mType   = aType;
+            tRec.mAction = aAction;
+            tRec.mDepth  = aDepth;
+        }
+
+        tRec.mVisitCount++;
+        tRec.mWallTimeSum += aWallSeconds;
+        tRec.mMemDeltaSum += aMemDeltaMb;
+
+        if ( aMemDeltaMb > tRec.mMemDeltaPeak )
+        {
+            tRec.mMemDeltaPeak = aMemDeltaMb;
+        }
+    }
+
+    //------------------------------------------------------------------------------
+
+    void
+    Performance_Reporter::update_peak_rss( real aMemMb )
+    {
+        if ( !mEnabled )
+        {
+            return;
+        }
+
+        if ( aMemMb > mPeakMemMb )
+        {
+            mPeakMemMb = aMemMb;
+        }
+    }
+
+    //------------------------------------------------------------------------------
+
+    void
+    Performance_Reporter::finalize()
+    {
+        // no-op if a run was never started (e.g. unit-test executables)
+        if ( !mEnabled )
+        {
+            return;
+        }
+
+        // ----- run-level aggregation (collective on all ranks) -----
+        std::chrono::duration< double > tWall = std::chrono::system_clock::now() - mRunWallStart;
+
+        real tRunWallLocal = tWall.count();
+        real tRunWallMax   = reduce_all( tRunWallLocal, MPI_MAX );
+        real tPeakMemMax   = reduce_all( mPeakMemMb, MPI_MAX );
+
+        // ----- check that all ranks recorded the same number of regions -----
+        real tCountLocal = (real)mRecords.size();
+        bool tAligned    = ( reduce_all( tCountLocal, MPI_MAX ) == reduce_all( tCountLocal, MPI_MIN ) );
+
+        // ----- per-region cross-rank wall-time stats (collective, in sorted-key lockstep) -----
+        std::vector< Display_Row > tRows;
+        tRows.reserve( mRecords.size() );
+
+        for ( auto& tEntry : mRecords )
+        {
+            Display_Row tRow;
+            tRow.mRecord = tEntry.second;
+
+            if ( tAligned )
+            {
+                tRow.mWallMax = reduce_all( tEntry.second.mWallTimeSum, MPI_MAX );
+                tRow.mWallMin = reduce_all( tEntry.second.mWallTimeSum, MPI_MIN );
+            }
+            else
+            {
+                // ranks diverged - fall back to local values, no cross-rank min/max
+                tRow.mWallMax = tEntry.second.mWallTimeSum;
+                tRow.mWallMin = tEntry.second.mWallTimeSum;
+            }
+
+            tRows.push_back( tRow );
+        }
+
+        // only rank 0 emits the report; all collective calls are above this guard
+        if ( par_rank() != 0 )
+        {
+            return;
+        }
+
+        // drop regions filtered out by the current granularity level and sort by cost
+        tRows.erase(
+                std::remove_if( tRows.begin(), tRows.end(),
+                        [ & ]( const Display_Row& aRow ) { return !include_in_report( aRow.mRecord.mDepth ); } ),
+                tRows.end() );
+
+        std::sort( tRows.begin(), tRows.end(),
+                []( const Display_Row& aL, const Display_Row& aR ) {
+                    return aL.mRecord.mWallTimeSum > aR.mRecord.mWallTimeSum;
+                } );
+
+        // ----- console summary table -----
+        std::ostringstream tOut;
+        tOut << "\n";
+        tOut << "==================== MORIS Performance Report (level " << mLevel << ") ====================\n";
+
+        if ( mLevel > 0 )
+        {
+            tOut << std::left << std::setw( 38 ) << "Module (entity - action)"
+                 << std::right << std::setw( 7 ) << "Visits"
+                 << std::setw( 12 ) << "Wall[s]"
+                 << std::setw( 18 ) << "Wall max/min"
+                 << std::setw( 13 ) << "MemD[MB]"
+                 << std::setw( 13 ) << "MemDpeak\n";
+            tOut << "-------------------------------------------------------------------------------------------------------\n";
+
+            for ( const Display_Row& tRow : tRows )
+            {
+                const Module_Performance_Record& tRec = tRow.mRecord;
+
+                std::string tLabel = tRec.mEntity + " - " + tRec.mAction;
+                if ( tLabel.size() > 37 )
+                {
+                    tLabel = tLabel.substr( 0, 34 ) + "...";
+                }
+
+                std::ostringstream tMaxMin;
+                tMaxMin << std::fixed << std::setprecision( 2 ) << tRow.mWallMax << "/" << tRow.mWallMin;
+
+                // clamp the reported growth at zero (negative deltas are allocator noise)
+                real tGrowth = tRec.mMemDeltaSum > 0.0 ? tRec.mMemDeltaSum : 0.0;
+
+                tOut << std::left << std::setw( 38 ) << tLabel
+                     << std::right << std::setw( 7 ) << tRec.mVisitCount
+                     << std::setw( 12 ) << std::fixed << std::setprecision( 3 ) << tRec.mWallTimeSum
+                     << std::setw( 18 ) << tMaxMin.str()
+                     << std::setw( 13 ) << std::fixed << std::setprecision( 1 ) << tGrowth
+                     << std::setw( 12 ) << std::fixed << std::setprecision( 1 ) << tRec.mMemDeltaPeak
+                     << "\n";
+            }
+
+            tOut << "-------------------------------------------------------------------------------------------------------\n";
+        }
+
+        tOut << "Run total wall (max over ranks): " << std::fixed << std::setprecision( 3 ) << tRunWallMax << " s"
+             << "   |   Peak memory (max over ranks): " << std::fixed << std::setprecision( 1 ) << tPeakMemMax
+             << " MB [" << mMemSource << "]\n";
+        tOut << "Report written to: " << mJsonPath << "\n";
+        tOut << "=======================================================================================================\n";
+
+        // emit to console and ASCII log
+        MORIS_LOG( "%s", tOut.str().c_str() );
+
+        // ----- JSON report -----
+        Json tRoot;
+        tRoot.put( "level", mLevel );
+        tRoot.put( "run_total_wall_s", tRunWallMax );
+        tRoot.put( "peak_mem_mb", tPeakMemMax );
+        tRoot.put( "mem_source", mMemSource );
+        tRoot.put( "ranks_aligned", tAligned );
+
+        Json tModules;
+        for ( const Display_Row& tRow : tRows )
+        {
+            const Module_Performance_Record& tRec = tRow.mRecord;
+
+            Json tModule;
+            tModule.put( "entity", tRec.mEntity );
+            tModule.put( "type", tRec.mType );
+            tModule.put( "action", tRec.mAction );
+            tModule.put( "depth", tRec.mDepth );
+            tModule.put( "visits", tRec.mVisitCount );
+            tModule.put( "wall_s", tRec.mWallTimeSum );
+            tModule.put( "wall_s_max", tRow.mWallMax );
+            tModule.put( "wall_s_min", tRow.mWallMin );
+            tModule.put( "mem_delta_mb", tRec.mMemDeltaSum );
+            tModule.put( "mem_delta_peak_mb", tRec.mMemDeltaPeak );
+
+            tModules.push_back( { "", tModule } );
+        }
+        tRoot.add_child( "modules", tModules );
+
+        write_json( mJsonPath, tRoot );
+    }
+
+    //------------------------------------------------------------------------------
+
+}    // namespace moris

--- a/projects/MRS/IOS/src/cl_Performance_Reporter.hpp
+++ b/projects/MRS/IOS/src/cl_Performance_Reporter.hpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2022 University of Colorado
+ * Licensed under the MIT license. See LICENSE.txt file in the MORIS root for details.
+ *
+ *------------------------------------------------------------------------------------
+ *
+ * cl_Performance_Reporter.hpp
+ *
+ */
+
+#ifndef MORIS_IOS_CL_PERFORMANCE_REPORTER_HPP_
+#define MORIS_IOS_CL_PERFORMANCE_REPORTER_HPP_
+
+#include <chrono>
+#include <map>
+#include <string>
+
+#include "moris_typedefs.hpp"
+
+namespace moris
+{
+    //------------------------------------------------------------------------------
+
+    /**
+     * One accumulated performance record for a single tracer region, keyed by the
+     * (entity, type, action) triple it was signed in with. Values are summed over
+     * every visit to that region across the whole run (i.e. across optimization
+     * iterations, since each iteration re-enters the same named regions).
+     */
+    struct Module_Performance_Record
+    {
+        std::string mEntity;
+        std::string mType;
+        std::string mAction;
+
+        uint mDepth        = 0;      // indentation level when the region was first seen
+        uint mVisitCount   = 0;      // number of sign-out events for this region
+        real mWallTimeSum  = 0.0;    // wall time [s], summed over visits
+        real mMemDeltaSum  = 0.0;    // memory change [MB], summed over visits
+        real mMemDeltaPeak = 0.0;    // largest single-visit memory growth [MB]
+    };
+
+    //------------------------------------------------------------------------------
+
+    /**
+     * Consolidated end-of-run performance report. A single global instance
+     * (gPerfReporter) is fed by Logger::sign_out for every tracer-bounded region;
+     * at the end of the run finalize() aggregates across MPI ranks, prints a console
+     * summary table, and writes a JSON report.
+     *
+     * The reporter is a passive consumer of the existing tracer events - it adds no
+     * instrumentation of its own. Everything is a no-op until initialize() is called,
+     * so test executables that link IOS but never start a run are unaffected.
+     */
+    class Performance_Reporter
+    {
+        //------------------------------------ PRIVATE -----------------------------
+
+      private:
+        bool        mEnabled  = false;
+        sint        mLevel    = 1;                    // granularity, see initialize()
+        std::string mJsonPath = "perf_report.json";
+        std::string mMemSource = "proc_rss";          // "tcmalloc" or "proc_rss"
+
+        real mPeakMemMb = 0.0;                         // per-rank high-water memory mark
+
+        std::chrono::system_clock::time_point mRunWallStart;
+
+        // accumulated records keyed by "entity|type|action" (std::map -> sorted,
+        // deterministic iteration order across ranks for MPI aggregation)
+        std::map< std::string, Module_Performance_Record > mRecords;
+
+        // returns true if a region at the given depth is shown for the current level
+        bool include_in_report( uint aDepth ) const;
+
+        //------------------------------------ PUBLIC ------------------------------
+
+      public:
+        Performance_Reporter() = default;
+
+        //--------------------------------------------------------------------------
+
+        /**
+         * Enable reporting and set the granularity level.
+         *
+         * Levels:
+         *  0 - run total only (total wall time + peak memory)
+         *  1 - top-level modules (HMR, XTK, GEN, MDL, ...), one row each
+         *  2 - modules + nested sub-regions (e.g. MDL forward/sensitivity, SOL)
+         *  3 - full nested tracer tree
+         *
+         * @param aLevel    granularity level (clamped to [0,3])
+         * @param aJsonPath path of the JSON report written on rank 0
+         */
+        void initialize( sint aLevel, const std::string& aJsonPath );
+
+        //--------------------------------------------------------------------------
+
+        /**
+         * Record a completed tracer region. Called from Logger::sign_out.
+         *
+         * @param aEntity      entity base (e.g. "HMR")
+         * @param aType        entity type
+         * @param aAction      entity action (e.g. "Perform Forward Analysis")
+         * @param aDepth       indentation level of the region
+         * @param aWallSeconds wall time spent in the region [s]
+         * @param aMemDeltaMb  memory change across the region [MB]
+         */
+        void record_region(
+                const std::string& aEntity,
+                const std::string& aType,
+                const std::string& aAction,
+                uint               aDepth,
+                real               aWallSeconds,
+                real               aMemDeltaMb );
+
+        //--------------------------------------------------------------------------
+
+        // update the run-level peak (high-water) memory mark [MB]
+        void update_peak_rss( real aMemMb );
+
+        //--------------------------------------------------------------------------
+
+        // aggregate across ranks, print the console table and write the JSON report
+        void finalize();
+
+        //--------------------------------------------------------------------------
+
+        bool is_enabled() const { return mEnabled; }
+        sint level() const { return mLevel; }
+
+        //--------------------------------------------------------------------------
+
+    };    // class Performance_Reporter
+
+}    // namespace moris
+
+// global performance reporter, defined in cl_Performance_Reporter.cpp
+extern moris::Performance_Reporter gPerfReporter;
+
+#endif /* MORIS_IOS_CL_PERFORMANCE_REPORTER_HPP_ */

--- a/projects/MRS/IOS/test/CMakeLists.txt
+++ b/projects/MRS/IOS/test/CMakeLists.txt
@@ -14,7 +14,8 @@ set(TEST_SOURCES
     cl_Logger.cpp
     fn_to_stdio.cpp
     UT_IOS_Parsing_Tool.cpp
-    UT_IOS_File_To_Array.cpp )
+    UT_IOS_File_To_Array.cpp
+    UT_IOS_Performance_Reporter.cpp )
 
 # List additional includes
 include_directories(${MORIS_DIR}/snippets/ios)

--- a/projects/MRS/IOS/test/UT_IOS_Performance_Reporter.cpp
+++ b/projects/MRS/IOS/test/UT_IOS_Performance_Reporter.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2022 University of Colorado
+ * Licensed under the MIT license. See LICENSE.txt file in the MORIS root for details.
+ *
+ *------------------------------------------------------------------------------------
+ *
+ * UT_IOS_Performance_Reporter.cpp
+ *
+ */
+
+#include <catch.hpp>
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
+#include "cl_Communication_Tools.hpp"       // COM/src
+#include "cl_Performance_Reporter.hpp"      // MRS/IOS/src
+#include "cl_Tracer.hpp"                    // MRS/IOS/src
+
+// ----------------------------------------------------------------------------
+
+TEST_CASE(
+        "Performance_Reporter accumulates and writes a JSON report",
+        "[moris],[ios],[performance_reporter]" )
+{
+    const std::string tJsonPath = "ut_perf_report.json";
+    std::remove( tJsonPath.c_str() );
+
+    // enable the reporter at full granularity
+    gPerfReporter.initialize( 3, tJsonPath );
+
+    // --- direct API: deterministic accumulation across repeated visits ---
+    // ModuleA is visited twice: wall 2.0 + 3.0 = 5.0 s, mem 10.0 + (-4.0) = 6.0 MB
+    gPerfReporter.record_region( "UT_PERF", "ModuleA", "Compute", 1, 2.0, 10.0 );
+    gPerfReporter.record_region( "UT_PERF", "ModuleA", "Compute", 1, 3.0, -4.0 );
+    // ModuleB is visited once
+    gPerfReporter.record_region( "UT_PERF", "ModuleB", "Assemble", 1, 1.5, 5.0 );
+
+    gPerfReporter.update_peak_rss( 123.0 );
+
+    // --- integration: a real Tracer scope drives gLogger.sign_in/sign_out,
+    // which in turn feeds gPerfReporter.record_region (proves the hook is wired) ---
+    {
+        moris::Tracer tTracer( "UT_PERF", "Traced", "Run" );
+    }
+
+    // aggregate across ranks, print the table, and write the JSON report
+    gPerfReporter.finalize();
+
+    // only rank 0 writes the report
+    if ( moris::par_rank() == 0 )
+    {
+        std::ifstream tIfs( tJsonPath );
+        REQUIRE( tIfs.good() );
+
+        boost::property_tree::ptree tTree;
+        boost::property_tree::read_json( tIfs, tTree );
+
+        // run-level fields
+        REQUIRE( tTree.get< int >( "level" ) == 3 );
+        REQUIRE( tTree.get< double >( "peak_mem_mb" ) >= 123.0 );
+        REQUIRE( tTree.count( "modules" ) == 1 );
+
+        // find the ModuleA / ModuleB records and check the accumulated values
+        bool tFoundA = false;
+        bool tFoundB = false;
+        bool tFoundTraced = false;
+
+        for ( const auto& tModule : tTree.get_child( "modules" ) )
+        {
+            const std::string tEntity = tModule.second.get< std::string >( "entity" );
+            const std::string tType   = tModule.second.get< std::string >( "type" );
+
+            if ( tEntity == "UT_PERF" && tType == "ModuleA" )
+            {
+                tFoundA = true;
+                CHECK( tModule.second.get< int >( "visits" ) == 2 );
+                CHECK( tModule.second.get< double >( "wall_s" ) == Approx( 5.0 ) );
+                CHECK( tModule.second.get< double >( "mem_delta_mb" ) == Approx( 6.0 ) );
+                CHECK( tModule.second.get< double >( "mem_delta_peak_mb" ) == Approx( 10.0 ) );
+            }
+            else if ( tEntity == "UT_PERF" && tType == "ModuleB" )
+            {
+                tFoundB = true;
+                CHECK( tModule.second.get< int >( "visits" ) == 1 );
+                CHECK( tModule.second.get< double >( "wall_s" ) == Approx( 1.5 ) );
+            }
+            else if ( tEntity == "UT_PERF" && tType == "Traced" )
+            {
+                // the Tracer-driven region: proves Logger::sign_out -> record_region works
+                tFoundTraced = true;
+                CHECK( tModule.second.get< int >( "visits" ) == 1 );
+            }
+        }
+
+        REQUIRE( tFoundA );
+        REQUIRE( tFoundB );
+        REQUIRE( tFoundTraced );
+
+        // clean up the artifact
+        std::remove( tJsonPath.c_str() );
+    }
+}

--- a/projects/MTK/src/io/cl_MTK_Exodus_IO_Helper.cpp
+++ b/projects/MTK/src/io/cl_MTK_Exodus_IO_Helper.cpp
@@ -8,6 +8,9 @@
  *
  */
 
+#include <cstring>
+#include <vector>
+
 #include "cl_Communication_Tools.hpp"
 #include "cl_MTK_Exodus_IO_Helper.hpp"
 #include "cl_Logger.hpp"
@@ -42,6 +45,31 @@ namespace moris::mtk
 
         MORIS_ERROR( cpu_ws == io_ws,
                 "Word size of floating point variables stored in exodus file and used in moris are not the same." );
+
+        // detect the MORIS id-convention QA stamp: files written by mtk::Writer_Exodus
+        // store moris_id + 1 in their id maps and carry "exodus_ids=moris_id+1"; external
+        // (e.g. Cubit) and pre-stamp files do not, and their ids are used verbatim --
+        // see share/doc/Dev_XTK_Ids_And_Indices.dox
+        int tNumQa = ex_inquire_int( mExoFileId, EX_INQ_QA );
+        if ( tNumQa > 0 )
+        {
+            std::vector< char >  tQaBuffer( 4 * tNumQa * ( MAX_STR_LENGTH + 1 ), '\0' );
+            std::vector< char* > tQaPointers( 4 * tNumQa );
+            for ( int i = 0; i < 4 * tNumQa; ++i )
+            {
+                tQaPointers[ i ] = tQaBuffer.data() + i * ( MAX_STR_LENGTH + 1 );
+            }
+            if ( ex_get_qa( mExoFileId, reinterpret_cast< char*( * )[ 4 ] >( tQaPointers.data() ) ) >= 0 )
+            {
+                for ( int i = 0; i < tNumQa; ++i )
+                {
+                    if ( std::strstr( tQaPointers[ 4 * i + 1 ], "exodus_ids=moris_id+1" ) != nullptr )
+                    {
+                        mMorisIdOffset = 1;
+                    }
+                }
+            }
+        }
 
         get_init_mesh_data();
         get_init_global();
@@ -1484,8 +1512,10 @@ namespace moris::mtk
     uint
     Exodus_IO_Helper::get_node_index_by_Id( uint aNodeId )
     {
-        // find index of node given its nodeId
-        auto tItr = std::find( mNodeNumMap.data(), mNodeNumMap.data() + mNumNodes, aNodeId );
+        // aNodeId is a MORIS node id; MORIS-written (QA-stamped) files store moris_id + 1
+        // in their id maps, external/pre-stamp files store ids verbatim -- the offset was
+        // detected at open; see share/doc/Dev_XTK_Ids_And_Indices.dox
+        auto tItr = std::find( mNodeNumMap.data(), mNodeNumMap.data() + mNumNodes, aNodeId + mMorisIdOffset );
 
         // compute index
         uint tIndex = std::distance( mNodeNumMap.data(), tItr );

--- a/projects/MTK/src/io/cl_MTK_Exodus_IO_Helper.hpp
+++ b/projects/MTK/src/io/cl_MTK_Exodus_IO_Helper.hpp
@@ -25,6 +25,11 @@ namespace moris::mtk
         bool mVerbose     = false;
         bool mBuildGlobal = false;
 
+        // +1 iff the file carries the MORIS QA stamp "exodus_ids=moris_id+1" (files written
+        // by mtk::Writer_Exodus); 0 for external / pre-stamp files, whose ids are used
+        // verbatim in by-id lookups -- see share/doc/Dev_XTK_Ids_And_Indices.dox
+        int mMorisIdOffset = 0;
+
         // general mesh info
         int         mNumDim      = -1;
         int         mNumNodes    = -1;

--- a/projects/MTK/src/io/cl_MTK_Writer_Exodus.cpp
+++ b/projects/MTK/src/io/cl_MTK_Writer_Exodus.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <exodusII.h>
+#include <ctime>
 
 #include "cl_MTK_Writer_Exodus.hpp"
 #include "cl_MTK_Mesh_Core.hpp"
@@ -735,6 +736,24 @@ namespace moris::mtk
                 (int)mElementBlockIndices.size(),
                 (int)mNodeSetIndices.size(),
                 (int)mSideSetIndices.size() );
+
+        // stamp the id convention as a QA record so readers can detect that this file's
+        // id maps store moris_id + 1 (exodus ids are 1-based); external files (e.g.
+        // Cubit) carry no stamp and their ids are used verbatim -- see
+        // share/doc/Dev_XTK_Ids_And_Indices.dox
+        {
+            time_t    tNow = time( nullptr );
+            struct tm tLocal;
+            localtime_r( &tNow, &tLocal );
+            char tDate[ MAX_STR_LENGTH + 1 ];
+            char tTime[ MAX_STR_LENGTH + 1 ];
+            strftime( tDate, sizeof( tDate ), "%Y-%m-%d", &tLocal );
+            strftime( tTime, sizeof( tTime ), "%H:%M:%S", &tLocal );
+            char  tCode[] = "MORIS";
+            char  tDesc[] = "exodus_ids=moris_id+1";
+            char* tQaRecord[ 1 ][ 4 ] = { { tCode, tDesc, tDate, tTime } };
+            ex_put_qa( mExoID, 1, tQaRecord );
+        }
     }
 
     //--------------------------------------------------------------------------------------------------------------
@@ -918,7 +937,9 @@ namespace moris::mtk
             // Get global ids for id map using either MTK or ad-hoc node ID map
             if ( mMtkIndexMap )
             {
-                tNodeMap( tNodeIndex ) = mMesh->get_glb_entity_id_from_entity_loc_index( tNodeIndex, EntityRank::NODE );
+                // add 1 since exodus id maps are 1-based (an id of 0 is invalid) while MORIS
+                // global ids are 0-based; see share/doc/Dev_XTK_Ids_And_Indices.dox
+                tNodeMap( tNodeIndex ) = mMesh->get_glb_entity_id_from_entity_loc_index( tNodeIndex, EntityRank::NODE ) + 1;
             }
             else
             {
@@ -1110,7 +1131,9 @@ namespace moris::mtk
                 // Assign exodus element id using either MTK or ad-hoc map
                 if ( mMtkIndexMap )
                 {
-                    tExodusTotalElementIds( tElemCounter++ ) = tElementIDs( tElementNumber );
+                    // add 1 since exodus id maps are 1-based (an id of 0 is invalid) while MORIS
+                    // global ids are 0-based; see share/doc/Dev_XTK_Ids_And_Indices.dox
+                    tExodusTotalElementIds( tElemCounter++ ) = tElementIDs( tElementNumber ) + 1;
                 }
                 else
                 {

--- a/projects/OPT/src/CMakeLists.txt
+++ b/projects/OPT/src/CMakeLists.txt
@@ -15,6 +15,7 @@ set(${OPT}_VERSION ${MORIS_VERSION})
 set(HEADERS
     cl_OPT_Algorithm.hpp
     cl_OPT_Algorithm_GCMMA.hpp
+    cl_OPT_Algorithm_MMA.hpp
     cl_OPT_Algorithm_LBFGS.hpp
     cl_OPT_Algorithm_SQP.hpp
     cl_OPT_Algorithm_Sweep.hpp
@@ -34,6 +35,7 @@ set(HEADERS
 set(LIB_SOURCES
     cl_OPT_Algorithm.cpp
     cl_OPT_Algorithm_GCMMA.cpp
+    cl_OPT_Algorithm_MMA.cpp
     cl_OPT_Algorithm_LBFGS.cpp
     cl_OPT_Algorithm_SQP.cpp
     cl_OPT_Algorithm_Sweep.cpp

--- a/projects/OPT/src/cl_OPT_Algorithm_GCMMA.cpp
+++ b/projects/OPT/src/cl_OPT_Algorithm_GCMMA.cpp
@@ -19,6 +19,9 @@
 #ifdef MORIS_HAVE_GCMMA
 #include "optalggcmmacall.hpp"
 #include "mma.hpp"
+
+#include <algorithm>
+#include <cmath>
 #endif
 
 using namespace moris;
@@ -192,6 +195,32 @@ opt_alg_gcmma_func_wrap(
         double&      aObjval,
         double*      aConval )
 {
+    // Guard: the TPL solver's internal asymptote arithmetic can overflow on degenerate
+    // evaluations (huge objective/gradient jumps from near-degenerate XFEM cuts) and hand
+    // back non-finite ADVs. Evaluating those would compute garbage criteria and trip the
+    // gradient-consistency assert. Route into the existing optimizer-restart mechanism
+    // instead: the problem re-initializes from the current design and the solve resumes.
+    for ( uint iADVIndex = 0; iADVIndex < aOptAlgGCMMA->mProblem->get_num_advs(); iADVIndex++ )
+    {
+        if ( !std::isfinite( aAdv[ iADVIndex ] ) )
+        {
+            MORIS_LOG_WARNING( "GCMMA produced a non-finite design vector; requesting optimizer restart." );
+
+            aOptAlgGCMMA->mProblem->request_restart();
+
+            // signal the TPL solver to exit its iteration loop
+            aIter = -aIter;
+
+            // return the last evaluated (finite) objective and constraints
+            aObjval = aOptAlgGCMMA->get_objectives()( 0 );
+
+            auto tLastConval = aOptAlgGCMMA->get_constraints().data();
+            std::copy( tLastConval, tLastConval + aOptAlgGCMMA->mProblem->get_num_constraints(), aConval );
+
+            return;
+        }
+    }
+
     // Update the ADV matrix
     Vector< real > tADVs( aOptAlgGCMMA->mProblem->get_num_advs() );
     for ( uint iADVIndex = 0; iADVIndex < tADVs.size(); iADVIndex++ )
@@ -229,6 +258,24 @@ opt_alg_gcmma_grad_wrap(
         double**     aD_Con,
         int*         aActive )
 {
+    // Guard: companion to the func_wrap non-finite-ADV guard. A restart is already
+    // pending, so return zero gradients (the TPL solver exits before using them)
+    // instead of tripping the ADV-consistency assert in the problem.
+    for ( uint iADVIndex = 0; iADVIndex < aOptAlgGCMMA->mProblem->get_num_advs(); iADVIndex++ )
+    {
+        if ( !std::isfinite( aAdv[ iADVIndex ] ) )
+        {
+            std::fill( aD_Obj, aD_Obj + aOptAlgGCMMA->mProblem->get_num_advs(), 0.0 );
+
+            for ( moris::uint i = 0; i < aOptAlgGCMMA->mProblem->get_num_constraints(); ++i )
+            {
+                std::fill( aD_Con[ i ], aD_Con[ i ] + aOptAlgGCMMA->mProblem->get_num_advs(), 0.0 );
+            }
+
+            return;
+        }
+    }
+
     // Update the vector of active constraints flag
     aOptAlgGCMMA->mActive = Matrix< DDSMat >( *aActive, aOptAlgGCMMA->mProblem->get_num_constraints(), 1 );
 

--- a/projects/OPT/src/cl_OPT_Algorithm_GCMMA.cpp
+++ b/projects/OPT/src/cl_OPT_Algorithm_GCMMA.cpp
@@ -69,6 +69,9 @@ OptAlgGCMMA::solve(
     // running status has to be wait when starting a solve
     mRunning = opt::Task::wait;
 
+    // fresh solve (possibly after a restart): objective scale re-derives from the first gradient
+    mObjScale = 1.0;
+
     mCurrentOptAlgInd = aCurrentOptAlgInd;    // set index of current optimization algorithm
     mProblem          = aOptProb;             // set the member variable mProblem to aOptProb
 
@@ -234,8 +237,8 @@ opt_alg_gcmma_func_wrap(
     // Update for objectives and constraints
     aOptAlgGCMMA->compute_design_criteria( tADVs );
 
-    // Convert outputs from type MORIS
-    aObjval = aOptAlgGCMMA->get_objectives()( 0 );
+    // Convert outputs from type MORIS (objective in the solver's current uniform scale)
+    aObjval = aOptAlgGCMMA->mObjScale * aOptAlgGCMMA->get_objectives()( 0 );
 
     // Update the pointer of constraints
     auto tConval = aOptAlgGCMMA->get_constraints().data();
@@ -292,7 +295,35 @@ opt_alg_gcmma_grad_wrap(
     // copy objective gradient
     auto tD_Obj = aOptAlgGCMMA->get_objective_gradients().data();
 
-    std::copy( tD_Obj, tD_Obj + aOptAlgGCMMA->mProblem->get_num_advs(), aD_Obj );
+    // Uniform objective scaling: engage only above the pathology threshold and quantize the
+    // scale to decades (see header). Preserves the descent direction exactly; keeps the TPL
+    // subproblem inside its proven operating range while leaving healthy regimes untouched.
+    {
+        moris::real tRawMax = 0.0;
+        for ( moris::uint i = 0; i < aOptAlgGCMMA->mProblem->get_num_advs(); ++i )
+        {
+            tRawMax = std::max( tRawMax, std::abs( tD_Obj[ i ] ) );
+        }
+
+        moris::real tNewScale = 1.0;
+        if ( tRawMax > OptAlgGCMMA::sObjGradEngage )
+        {
+            // smallest power of ten that brings tRawMax at or below the target
+            tNewScale = std::pow( 10.0, -std::ceil( std::log10( tRawMax / OptAlgGCMMA::sObjGradTarget ) ) );
+        }
+
+        if ( tNewScale != aOptAlgGCMMA->mObjScale )
+        {
+            MORIS_LOG_INFO( "GCMMA: objective scale -> %.1e (raw max|dObj/dADV| = %.4e).",
+                    tNewScale, tRawMax );
+        }
+        aOptAlgGCMMA->mObjScale = tNewScale;
+    }
+
+    for ( moris::uint i = 0; i < aOptAlgGCMMA->mProblem->get_num_advs(); ++i )
+    {
+        aD_Obj[ i ] = aOptAlgGCMMA->mObjScale * tD_Obj[ i ];
+    }
 
     // Get the constraint gradient as a MORIS Matrix
     Matrix< DDRMat > tD_Con = aOptAlgGCMMA->get_constraint_gradients();

--- a/projects/OPT/src/cl_OPT_Algorithm_GCMMA.cpp
+++ b/projects/OPT/src/cl_OPT_Algorithm_GCMMA.cpp
@@ -42,6 +42,9 @@ OptAlgGCMMA::OptAlgGCMMA( const Parameter_List& aParameterList )
     mRestartIndex         = aParameterList.get< moris::sint >( "restart_index" );
     mMaxIterationsInitial = aParameterList.get< moris::sint >( "max_its" );
     mMaxIterations        = mMaxIterationsInitial;
+    
+    MORIS_LOG_INFO( "GCMMA initialized: max_its=%d, step_size=%.6f, penalty=%.2f",
+            mMaxIterations, mStepSize, mPenalty );
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/projects/OPT/src/cl_OPT_Algorithm_GCMMA.hpp
+++ b/projects/OPT/src/cl_OPT_Algorithm_GCMMA.hpp
@@ -34,6 +34,19 @@ private:
     moris::real mPenalty;             // GCMMA constraint penalty
     moris::sint mIvers;               // GCMMA version
 
+    // Uniform objective scaling (degenerate-evaluation safeguard): the TPL solver's internal
+    // arithmetic overflows to NaN when degenerate XFEM cuts push the objective gradient past
+    // ~1e10, while gradients up to ~1e8 are demonstrably handled raw. When max|dObj/dADV|
+    // exceeds the engage threshold, objective and gradient are scaled uniformly (preserves
+    // the descent direction exactly) by a DECADE-QUANTIZED factor that brings the max into
+    // [target/10, target]. Quantization matters: the TPL's stored objective value cannot be
+    // re-booked when the scale changes, so every change costs one inconsistent
+    // conservativeness check -- a continuously re-derived scale corrupts every iteration,
+    // while a quantized one only transitions when the gradient magnitude crosses a decade.
+    moris::real                  mObjScale = 1.0;
+    static constexpr moris::real sObjGradEngage = 1.0e9;    ///< scale only above this (true pathology)
+    static constexpr moris::real sObjGradTarget = 1.0e8;    ///< scaled max lands in (1e7, 1e8]
+
     /**
      * @brief External function call for computing objective and constraints, to
      *        interface with gcmma library

--- a/projects/OPT/src/cl_OPT_Algorithm_MMA.cpp
+++ b/projects/OPT/src/cl_OPT_Algorithm_MMA.cpp
@@ -1,0 +1,959 @@
+/*
+ * Copyright (c) 2022 University of Colorado
+ * Licensed under the MIT license. See LICENSE.txt file in the MORIS root for details.
+ *
+ *------------------------------------------------------------------------------------
+ *
+ * cl_OPT_Algorithm_MMA.cpp
+ *
+ * Native port of Svanberg's GCMMA (2002). See header for provenance. The numerical
+ * arithmetic mirrors github.com/kkmaute/gcmma line-for-line; func()/grad() replace the
+ * TPL's opt_alg_gcmma_func_wrap/grad_wrap with direct calls to the inherited MORIS
+ * criteria evaluation, so MORIS owns the optimization loop.
+ */
+
+#include <cmath>
+#include <vector>
+
+#include "cl_OPT_Algorithm_MMA.hpp"
+#include "cl_Communication_Tools.hpp"
+#include "cl_Logger.hpp"
+#include "cl_Tracer.hpp"
+
+namespace moris::opt
+{
+    //------------------------------------------------------------------------------
+
+    Algorithm_MMA::Algorithm_MMA( const Parameter_List& aParameterList )
+            : mMaxInnerIter( aParameterList.get< sint >( "max_inner_its" ) )
+            , mNormDrop( aParameterList.get< real >( "norm_drop" ) )
+            , mAsympAdapt0( aParameterList.get< real >( "asymp_adapt0" ) )
+            , mAsympShrink( aParameterList.get< real >( "asymp_adaptb" ) )
+            , mAsympExpand( aParameterList.get< real >( "asymp_adaptc" ) )
+            , mStepSize( aParameterList.get< real >( "step_size" ) )
+            , mPenalty( aParameterList.get< real >( "penalty" ) )
+    {
+        mRestartIndex         = aParameterList.get< sint >( "restart_index" );
+        mMaxIterationsInitial = aParameterList.get< sint >( "max_its" );
+        mMaxIterations        = mMaxIterationsInitial;
+        mReinitHook           = aParameterList.get< bool >( "reinit_in_place" );
+
+        MORIS_LOG_INFO( "Native MMA initialized: max_its=%d, step_size=%.6f, penalty=%.2f%s",
+                (int)mMaxIterations, mStepSize, mPenalty, mReinitHook ? ", in-place reinit hook ON" : "" );
+    }
+
+    //------------------------------------------------------------------------------
+
+    Algorithm_MMA::~Algorithm_MMA() {}
+
+    //------------------------------------------------------------------------------
+
+    uint
+    Algorithm_MMA::solve(
+            uint                                   aCurrentOptAlgInd,
+            std::shared_ptr< moris::opt::Problem > aOptProb )
+    {
+        Tracer tTracer( "OptimizationAlgorithm", "MMA", "Solve" );
+
+        mRunning          = opt::Task::wait;
+        mCurrentOptAlgInd = aCurrentOptAlgInd;
+        mProblem          = aOptProb;
+
+        if ( mRestartIndex > 0 )
+        {
+            gLogger.set_opt_iteration( mRestartIndex );
+        }
+
+        if ( par_rank() == 0 )
+        {
+            this->mma_solve();
+
+            mRunning = opt::Task::exit;
+            this->communicate_running_status();
+        }
+        else
+        {
+            mPrint = false;
+            this->dummy_solve();
+        }
+
+        uint tOptIter = gLogger.get_opt_iteration();
+        gLogger.set_iteration( "OPT", "Manager", "Perform", tOptIter );
+
+        return tOptIter;
+    }
+
+    //------------------------------------------------------------------------------
+
+    void
+    Algorithm_MMA::func( double* aX, real& aF0, std::vector< double >& aF )
+    {
+        Vector< real > tADVs( mNumVar );
+        for ( int i = 0; i < mNumVar; ++i ) tADVs( i ) = aX[ i ];
+
+        this->compute_design_criteria( tADVs );
+
+        aF0 = this->get_objectives()( 0 );
+
+        const Matrix< DDRMat >& tCon = this->get_constraints();
+        for ( int j = 0; j < mNumCon; ++j ) aF[ j ] = tCon( j );
+
+        // In-place reinitialization hook: the workflow may have redistanced the design (overwritten
+        // tADVs with the SDF coefficients) during criteria evaluation. Store those separately rather
+        // than writing them back into aX -- this keeps xmma as the RAW subproblem solution so that
+        // raaupdate() and the conservatism check operate on the point the subproblem actually
+        // produced. The redistanced design is committed to xval after the step is accepted; the
+        // criteria call already set mADVs = tADVs, so the subsequent gradient call stays consistent.
+        if ( mReinitHook )
+        {
+            mLastRedistanced.assign( mNumVar, 0.0 );
+            for ( int i = 0; i < mNumVar; ++i ) mLastRedistanced[ i ] = tADVs( i );
+        }
+    }
+
+    //------------------------------------------------------------------------------
+
+    void
+    Algorithm_MMA::grad( const double* aX )
+    {
+        Vector< real > tADVs( mNumVar );
+        for ( int i = 0; i < mNumVar; ++i ) tADVs( i ) = aX[ i ];
+
+        this->compute_design_criteria_gradients( tADVs );
+
+        const Matrix< DDRMat >& tObjGrad = this->get_objective_gradients();      // 1 x numvar
+        const Matrix< DDRMat >& tConGrad = this->get_constraint_gradients();     // numcon x numvar
+
+        for ( int i = 0; i < mNumVar; ++i ) df0dx[ i ] = tObjGrad( 0, i );
+        for ( int j = 0; j < mNumCon; ++j )
+            for ( int i = 0; i < mNumVar; ++i ) dfdx[ j ][ i ] = tConGrad( j, i );
+    }
+
+    //------------------------------------------------------------------------------
+
+    bool
+    Algorithm_MMA::criteria_finite() const
+    {
+        if ( !std::isfinite( f0valnew ) ) return false;
+        for ( int j = 0; j < mNumCon; ++j )
+            if ( !std::isfinite( fvalnew[ j ] ) ) return false;
+        return true;
+    }
+
+    //------------------------------------------------------------------------------
+
+    void
+    Algorithm_MMA::mma_initialize()
+    {
+        mNumVar = (int)mProblem->get_num_advs();
+        mNumCon = (int)mProblem->get_num_constraints();
+
+        epsimin = std::sqrt( (double)( mNumCon + mNumVar ) ) * 1.0e-9;
+        raa0eps = 1.0e-7;
+        a0      = 1.0;
+        f0app   = 0.0;
+
+        auto allocV = [ & ]( std::vector< double >& v, int n ) { v.assign( n, 0.0 ); };
+
+        // size numvar
+        for ( auto* v : { &xval, &xold1, &xold2, &xmax, &xmin, &low, &upp, &alfa, &beta,
+                      &p0, &q0, &df0dx, &x, &xold, &delx, &diagx, &diagxinv, &xmma,
+                      &xsi, &xsiold, &dxsi, &eta, &etaold, &deta } )
+            allocV( *v, mNumVar );
+        allocV( dx, mNumVar + 1 );
+
+        // size numcon
+        for ( auto* v : { &fval, &fvalnew, &a, &b, &c, &d, &r, &raa, &fapp, &gvec,
+                      &y, &yold, &dy, &dely, &diagy, &diagyinv,
+                      &lamold, &dellam, &dellamyi, &diaglam, &diaglamyi, &diaglamyiinv,
+                      &mu, &muold, &dmu, &s, &sold, &ds } )
+            allocV( *v, mNumCon );
+        allocV( lam, mNumCon );
+        allocV( dlam, mNumCon + 1 );
+
+        // 2D numcon x numvar
+        P.assign( mNumCon, std::vector< double >( mNumVar, 0.0 ) );
+        Q.assign( mNumCon, std::vector< double >( mNumVar, 0.0 ) );
+        GG.assign( mNumCon, std::vector< double >( mNumVar, 0.0 ) );
+        dfdx.assign( mNumCon, std::vector< double >( mNumVar, 0.0 ) );
+
+        // dense Newton system, k = min(numcon,numvar)+1
+        int k = ( mNumCon < mNumVar ? mNumCon : mNumVar ) + 1;
+        AA.assign( k * k, 0.0 );
+        bb.assign( k, 0.0 );
+
+        // initial values (get_advs/bounds return Vector< real >&)
+        const Vector< real >& tAdv = mProblem->get_advs();
+        const Vector< real >& tUpp = mProblem->get_upper_bounds();
+        const Vector< real >& tLow = mProblem->get_lower_bounds();
+
+        for ( int i = 0; i < mNumVar; ++i )
+        {
+            xval[ i ]  = tAdv( i );
+            xmax[ i ]  = tUpp( i );
+            xmin[ i ]  = tLow( i );
+            xold1[ i ] = xval[ i ];
+            xold2[ i ] = xval[ i ];
+            low[ i ]   = xmin[ i ];
+            upp[ i ]   = xmax[ i ];
+            alfa[ i ]  = xmin[ i ];
+            beta[ i ]  = xmax[ i ];
+        }
+
+        for ( int j = 0; j < mNumCon; ++j )
+        {
+            a[ j ] = 0.0;
+            d[ j ] = 0.0;
+        }
+    }
+
+    //------------------------------------------------------------------------------
+
+    void
+    Algorithm_MMA::asymp( int iter )
+    {
+        if ( iter > 1.5 )
+        {
+            raa0 = mx( raa0eps, 0.1 * raa0 );
+            for ( int j = 0; j < mNumCon; ++j ) raa[ j ] = mx( raa0eps, 0.1 * raa[ j ] );
+        }
+
+        if ( iter < 2.5 )
+        {
+            for ( int i = 0; i < mNumVar; ++i )
+            {
+                low[ i ] = xval[ i ] - mAsympAdapt0 * ( xmax[ i ] - xmin[ i ] );
+                upp[ i ] = xval[ i ] + mAsympAdapt0 * ( xmax[ i ] - xmin[ i ] );
+            }
+        }
+        else
+        {
+            for ( int i = 0; i < mNumVar; ++i )
+            {
+                double factor = 1.0;
+                double xxx    = ( xval[ i ] - xold1[ i ] ) * ( xold1[ i ] - xold2[ i ] );
+
+                if ( xxx > 0 ) factor = mAsympExpand;
+                if ( xxx < 0 ) factor = mAsympShrink;
+
+                low[ i ] = xval[ i ] - factor * ( xold1[ i ] - low[ i ] );
+                upp[ i ] = xval[ i ] + factor * ( upp[ i ] - xold1[ i ] );
+
+                double lowmin = xval[ i ] - 10.0 * ( xmax[ i ] - xmin[ i ] );
+                double lowmax = xval[ i ] - 0.01 * ( xmax[ i ] - xmin[ i ] );
+                double uppmin = xval[ i ] + 0.01 * ( xmax[ i ] - xmin[ i ] );
+                double uppmax = xval[ i ] + 10.0 * ( xmax[ i ] - xmin[ i ] );
+
+                low[ i ] = mx( low[ i ], lowmin );
+                low[ i ] = mn( low[ i ], lowmax );
+                upp[ i ] = mn( upp[ i ], uppmax );
+                upp[ i ] = mx( upp[ i ], uppmin );
+            }
+        }
+
+        // diagnostic: asymptote spread (upp-low)/range per variable. The floor is 0.02*range
+        // (both asymptotes at their 0.01*range clamp). Variables collapsed to the floor have their
+        // move limit choked to ~1% of range -- effectively locked. Reports how many are locked.
+        {
+            real tMinSp = 1.0e30, tMaxSp = 0.0, tSumSp = 0.0;
+            int  tLocked = 0;
+            for ( int i = 0; i < mNumVar; ++i )
+            {
+                real tSp = ( upp[ i ] - low[ i ] ) / ( xmax[ i ] - xmin[ i ] );
+                tMinSp = mn( tMinSp, tSp );
+                tMaxSp = mx( tMaxSp, tSp );
+                tSumSp += tSp;
+                if ( tSp < 0.05 ) tLocked++;
+            }
+            MORIS_LOG_INFO( "MMA asymptote spread iter %d: min=%.4f mean=%.4f max=%.4f | %d/%d vars at floor (locked)",
+                    iter, tMinSp, tSumSp / (real)mNumVar, tMaxSp, tLocked, mNumVar );
+        }
+    }
+
+    //------------------------------------------------------------------------------
+
+    void
+    Algorithm_MMA::gcmmasub( int iter )
+    {
+        // move limit honors mMoveScale (shrunk by the NaN guard while backtracking off a bad step)
+        const real tStep = mStepSize * mMoveScale;
+        for ( int i = 0; i < mNumVar; ++i )
+        {
+            alfa[ i ] = mx( xmin[ i ], low[ i ] + 0.1 * ( xval[ i ] - low[ i ] ) );
+            alfa[ i ] = mx( alfa[ i ], xval[ i ] - tStep * ( xmax[ i ] - xmin[ i ] ) );
+
+            beta[ i ] = mn( xmax[ i ], upp[ i ] - 0.1 * ( upp[ i ] - xval[ i ] ) );
+            beta[ i ] = mn( beta[ i ], xval[ i ] + tStep * ( xmax[ i ] - xmin[ i ] ) );
+        }
+
+        r0 = f0val;
+        for ( int j = 0; j < mNumCon; ++j ) r[ j ] = fval[ j ];
+
+        for ( int i = 0; i < mNumVar; ++i )
+        {
+            double ux1 = upp[ i ] - xval[ i ];
+            double ux2 = ux1 * ux1;
+            double xl1 = xval[ i ] - low[ i ];
+            double xl2 = xl1 * xl1;
+            double ul1 = upp[ i ] - low[ i ];
+
+            double uxinv = 1.0 / ux1;
+            double xlinv = 1.0 / xl1;
+            double ulinv = 1.0 / ul1;
+
+            p0[ i ] = 0.0;
+            if ( df0dx[ i ] > 0 ) p0[ i ] = df0dx[ i ];
+            p0[ i ] += 0.5 * raa0 * ulinv;
+            p0[ i ] *= ux2;
+
+            q0[ i ] = 0.0;
+            if ( df0dx[ i ] < 0 ) q0[ i ] = -df0dx[ i ];
+            q0[ i ] += 0.5 * raa0 * ulinv;
+            q0[ i ] *= xl2;
+
+            r0 -= p0[ i ] * uxinv + q0[ i ] * xlinv;
+
+            for ( int j = 0; j < mNumCon; ++j )
+            {
+                P[ j ][ i ] = 0.0;
+                if ( dfdx[ j ][ i ] > 0 ) P[ j ][ i ] = dfdx[ j ][ i ];
+                P[ j ][ i ] += 0.5 * ulinv * raa[ j ];
+                P[ j ][ i ] *= ux2;
+
+                Q[ j ][ i ] = 0.0;
+                if ( dfdx[ j ][ i ] < 0 ) Q[ j ][ i ] = -dfdx[ j ][ i ];
+                Q[ j ][ i ] += 0.5 * ulinv * raa[ j ];
+                Q[ j ][ i ] *= xl2;
+
+                r[ j ] -= uxinv * P[ j ][ i ] + xlinv * Q[ j ][ i ];
+            }
+        }
+
+        for ( int j = 0; j < mNumCon; ++j ) b[ j ] = -r[ j ];
+
+        this->subsolve();
+
+        f0app = r0;
+        for ( int j = 0; j < mNumCon; ++j ) fapp[ j ] = r[ j ];
+
+        for ( int i = 0; i < mNumVar; ++i )
+        {
+            double ux1   = upp[ i ] - xmma[ i ];
+            double xl1   = xmma[ i ] - low[ i ];
+            double uxinv = 1.0 / ux1;
+            double xlinv = 1.0 / xl1;
+
+            f0app += uxinv * p0[ i ] + xlinv * q0[ i ];
+            for ( int j = 0; j < mNumCon; ++j ) fapp[ j ] += uxinv * P[ j ][ i ] + xlinv * Q[ j ][ i ];
+        }
+    }
+
+    //------------------------------------------------------------------------------
+
+    void
+    Algorithm_MMA::raaupdate()
+    {
+        double raacofmin = 1.0e-7;
+        double raacof    = 0.0;
+
+        for ( int i = 0; i < mNumVar; ++i )
+        {
+            double yyux = ( xmma[ i ] - xval[ i ] ) / ( upp[ i ] - xmma[ i ] );
+            double yyxl = ( xmma[ i ] - xval[ i ] ) / ( xmma[ i ] - low[ i ] );
+            raacof += 0.5 * yyux * yyxl;
+        }
+        raacof = mx( raacof, raacofmin );
+
+        if ( f0valnew > ( f0app + 0.5 * epsimin ) )
+        {
+            double deltaraa0 = ( 1.0 / raacof ) * ( f0valnew - f0app );
+            double zz0       = 1.1 * ( raa0 + deltaraa0 );
+            zz0              = mn( zz0, 10.0 * raa0 );
+            raa0             = zz0;
+        }
+
+        for ( int j = 0; j < mNumCon; ++j )
+        {
+            double fappe  = fapp[ j ] + 0.5 * epsimin;
+            double fdelta = fvalnew[ j ] - fappe;
+            if ( fdelta > 0.0 )
+            {
+                double deltaraa = ( 1.0 / raacof ) * ( fvalnew[ j ] - fapp[ j ] );
+                double zzz      = 1.1 * ( raa[ j ] + deltaraa );
+                raa[ j ]        = mn( zzz, 10.0 * raa[ j ] );
+            }
+        }
+    }
+
+    //------------------------------------------------------------------------------
+
+    int
+    Algorithm_MMA::kktcheck( real& aKKTrefres )
+    {
+        double residunorm = 0.0;
+        double residumax  = -1.0;
+
+        for ( int i = 0; i < mNumVar; ++i )
+        {
+            double rex   = df0dx[ i ] - xsi[ i ] + eta[ i ];
+            double rexsi = xsi[ i ] * ( xmma[ i ] - xmin[ i ] );
+            double reeta = eta[ i ] * ( xmax[ i ] - xmma[ i ] );
+
+            for ( int j = 0; j < mNumCon; ++j ) rex += dfdx[ j ][ i ] * lam[ j ];
+
+            residunorm += rex * rex;   residumax = mx( residumax, std::abs( rex ) );
+            residunorm += rexsi * rexsi; residumax = mx( residumax, std::abs( rexsi ) );
+            residunorm += reeta * reeta; residumax = mx( residumax, std::abs( reeta ) );
+        }
+
+        double rez   = a0 - zet;
+        double rezet = zet * z;
+
+        for ( int j = 0; j < mNumCon; ++j )
+        {
+            double rey   = c[ j ] + d[ j ] * y[ j ] - mu[ j ] - lam[ j ];
+            double relam = fval[ j ] - z * a[ j ] - y[ j ] + s[ j ];
+            double remu  = mu[ j ] * y[ j ];
+            double res   = lam[ j ] * s[ j ];
+            rez -= a[ j ] * lam[ j ];
+
+            residunorm += rey * rey;     residumax = mx( residumax, std::abs( rey ) );
+            residunorm += relam * relam; residumax = mx( residumax, std::abs( relam ) );
+            residunorm += remu * remu;   residumax = mx( residumax, std::abs( remu ) );
+            residunorm += res * res;     residumax = mx( residumax, std::abs( res ) );
+        }
+
+        residunorm += rez * rez;     residumax = mx( residumax, std::abs( rez ) );
+        residunorm += rezet * rezet; residumax = mx( residumax, std::abs( rezet ) );
+
+        residunorm = std::sqrt( residunorm );
+
+        double KKTres = mx( residunorm, residumax );
+
+        if ( aKKTrefres < 0 ) aKKTrefres = KKTres;
+
+        return ( KKTres > mNormDrop * aKKTrefres ) ? 0 : 1;
+    }
+
+    //------------------------------------------------------------------------------
+
+    void
+    Algorithm_MMA::solve_dense( std::vector< double >& A, std::vector< double >& X,
+            const std::vector< double >& B, int n )
+    {
+        // Gaussian elimination with partial pivoting on row-major A (n x n); solves A x = B.
+        // A is overwritten. Matches dgesv (LU partial pivot) numerics for these small systems.
+        X = B;
+        for ( int k = 0; k < n; ++k )
+        {
+            // pivot
+            int    piv  = k;
+            double pmax = std::abs( A[ k * n + k ] );
+            for ( int i = k + 1; i < n; ++i )
+            {
+                double v = std::abs( A[ i * n + k ] );
+                if ( v > pmax ) { pmax = v; piv = i; }
+            }
+            if ( piv != k )
+            {
+                for ( int j = 0; j < n; ++j ) std::swap( A[ k * n + j ], A[ piv * n + j ] );
+                std::swap( X[ k ], X[ piv ] );
+            }
+
+            double akk = A[ k * n + k ];
+            for ( int i = k + 1; i < n; ++i )
+            {
+                double f = A[ i * n + k ] / akk;
+                for ( int j = k; j < n; ++j ) A[ i * n + j ] -= f * A[ k * n + j ];
+                X[ i ] -= f * X[ k ];
+            }
+        }
+        // back substitution
+        for ( int i = n - 1; i >= 0; --i )
+        {
+            double sum = X[ i ];
+            for ( int j = i + 1; j < n; ++j ) sum -= A[ i * n + j ] * X[ j ];
+            X[ i ] = sum / A[ i * n + i ];
+        }
+    }
+
+    //------------------------------------------------------------------------------
+
+    void
+    Algorithm_MMA::subsolve()
+    {
+        const int numvar = mNumVar;
+        const int numcon = mNumCon;
+
+        for ( int i = 0; i < numvar; ++i )
+        {
+            x[ i ]   = 0.5 * ( alfa[ i ] + beta[ i ] );
+            xsi[ i ] = mx( 1.0, 1.0 / ( x[ i ] - alfa[ i ] ) );
+            eta[ i ] = mx( 1.0, 1.0 / ( beta[ i ] - x[ i ] ) );
+        }
+        for ( int j = 0; j < numcon; ++j )
+        {
+            y[ j ]   = 1.0;
+            lam[ j ] = 1.0;
+            mu[ j ]  = mx( 1.0, 0.5 * c[ j ] );
+            s[ j ]   = 1.0;
+        }
+        z   = 1.0;
+        zet = 1.0;
+
+        double epsi  = 1.0;
+        double dz = 0.0, dzet = 0.0, delz = 0.0;
+
+        std::vector< double > dlocal;   // scratch for dense solve result (size k)
+
+        while ( epsi > epsimin )
+        {
+            double residunorm = 0.0;
+            double residumax  = -1.0;
+
+            for ( int j = 0; j < numcon; ++j ) gvec[ j ] = 0.0;
+
+            for ( int i = 0; i < numvar; ++i )
+            {
+                double ux1    = upp[ i ] - x[ i ];
+                double xl1    = x[ i ] - low[ i ];
+                double ux2    = ux1 * ux1;
+                double xl2    = xl1 * xl1;
+                double uxinv1 = 1.0 / ux1;
+                double xlinv1 = 1.0 / xl1;
+
+                double plam = p0[ i ];
+                for ( int j = 0; j < numcon; ++j ) plam += P[ j ][ i ] * lam[ j ];
+                double qlam = q0[ i ];
+                for ( int j = 0; j < numcon; ++j ) qlam += Q[ j ][ i ] * lam[ j ];
+
+                double dpsidx = plam / ux2 - qlam / xl2;
+                double rex    = dpsidx - xsi[ i ] + eta[ i ];
+                double rexsi  = xsi[ i ] * ( x[ i ] - alfa[ i ] ) - epsi;
+                double reeta  = eta[ i ] * ( beta[ i ] - x[ i ] ) - epsi;
+
+                for ( int j = 0; j < numcon; ++j ) gvec[ j ] += P[ j ][ i ] * uxinv1 + Q[ j ][ i ] * xlinv1;
+
+                residunorm += rex * rex;     residumax = mx( residumax, std::abs( rex ) );
+                residunorm += rexsi * rexsi; residumax = mx( residumax, std::abs( rexsi ) );
+                residunorm += reeta * reeta; residumax = mx( residumax, std::abs( reeta ) );
+            }
+
+            double rez   = a0 - zet;
+            double rezet = zet * z - epsi;
+            for ( int j = 0; j < numcon; ++j )
+            {
+                double rey   = c[ j ] + d[ j ] * y[ j ] - mu[ j ] - lam[ j ];
+                double relam = gvec[ j ] - z * a[ j ] - y[ j ] + s[ j ] - b[ j ];
+                double remu  = mu[ j ] * y[ j ] - epsi;
+                double res   = lam[ j ] * s[ j ] - epsi;
+                rez -= a[ j ] * lam[ j ];
+
+                residunorm += rey * rey;     residumax = mx( residumax, std::abs( rey ) );
+                residunorm += relam * relam; residumax = mx( residumax, std::abs( relam ) );
+                residunorm += remu * remu;   residumax = mx( residumax, std::abs( remu ) );
+                residunorm += res * res;     residumax = mx( residumax, std::abs( res ) );
+            }
+            residunorm += rez * rez;     residumax = mx( residumax, std::abs( rez ) );
+            residunorm += rezet * rezet; residumax = mx( residumax, std::abs( rezet ) );
+            residunorm = std::sqrt( residunorm );
+
+            int ittt = 0;
+            while ( residumax > 0.9 * epsi && ittt < 200 )
+            {
+                ittt++;
+
+                for ( int j = 0; j < numcon; ++j ) gvec[ j ] = 0.0;
+
+                for ( int i = 0; i < numvar; ++i )
+                {
+                    double ux1 = upp[ i ] - x[ i ];
+                    double xl1 = x[ i ] - low[ i ];
+                    double ux2 = ux1 * ux1;
+                    double xl2 = xl1 * xl1;
+                    double ux3 = ux1 * ux2;
+                    double xl3 = xl1 * xl2;
+
+                    double uxinv1 = 1.0 / ux1;
+                    double xlinv1 = 1.0 / xl1;
+                    double uxinv2 = 1.0 / ux2;
+                    double xlinv2 = 1.0 / xl2;
+
+                    double plam = p0[ i ];
+                    for ( int j = 0; j < numcon; ++j ) plam += P[ j ][ i ] * lam[ j ];
+                    double qlam = q0[ i ];
+                    for ( int j = 0; j < numcon; ++j ) qlam += Q[ j ][ i ] * lam[ j ];
+
+                    double dpsidx = plam / ux2 - qlam / xl2;
+                    delx[ i ]     = dpsidx - epsi / ( x[ i ] - alfa[ i ] ) + epsi / ( beta[ i ] - x[ i ] );
+
+                    diagx[ i ]    = plam / ux3 + qlam / xl3;
+                    diagx[ i ]    = 2.0 * diagx[ i ] + xsi[ i ] / ( x[ i ] - alfa[ i ] ) + eta[ i ] / ( beta[ i ] - x[ i ] );
+                    diagxinv[ i ] = 1.0 / diagx[ i ];
+
+                    for ( int j = 0; j < numcon; ++j )
+                    {
+                        gvec[ j ]   += P[ j ][ i ] * uxinv1 + Q[ j ][ i ] * xlinv1;
+                        GG[ j ][ i ] = P[ j ][ i ] * uxinv2 - Q[ j ][ i ] * xlinv2;
+                    }
+                }
+
+                delz = a0 - epsi / z;
+                for ( int j = 0; j < numcon; ++j )
+                {
+                    dely[ j ]    = c[ j ] + d[ j ] * y[ j ] - lam[ j ] - epsi / y[ j ];
+                    dellam[ j ]  = gvec[ j ] - z * a[ j ] - y[ j ] - b[ j ] + epsi / lam[ j ];
+                    diagy[ j ]   = d[ j ] + mu[ j ] / y[ j ];
+                    diagyinv[ j ] = 1.0 / diagy[ j ];
+                    diaglam[ j ] = s[ j ] / lam[ j ];
+                    diaglamyi[ j ] = diaglam[ j ] + diagyinv[ j ];
+                    delz -= a[ j ] * lam[ j ];
+                }
+
+                if ( numcon < numvar )
+                {
+                    int    k  = numcon + 1;
+                    auto   AT = [ & ]( int i2, int j2 ) -> double& { return AA[ i2 * k + j2 ]; };
+
+                    AT( numcon, numcon ) = -zet / z;
+
+                    for ( int j = 0; j < numcon; ++j )
+                    {
+                        bb[ j ] = dellam[ j ] + dely[ j ] / diagy[ j ];
+                        for ( int i = 0; i < numvar; ++i ) bb[ j ] -= GG[ j ][ i ] * ( delx[ i ] / diagx[ i ] );
+                    }
+                    bb[ numcon ] = delz;
+
+                    for ( int j = 0; j < numcon; ++j )
+                    {
+                        for ( int jj = 0; jj < numcon; ++jj )
+                        {
+                            double sum = 0.0;
+                            for ( int i = 0; i < numvar; ++i ) sum += GG[ j ][ i ] * GG[ jj ][ i ] * diagxinv[ i ];
+                            AT( j, jj ) = sum;
+                        }
+                        AT( j, j ) += diaglamyi[ j ];
+                        AT( numcon, j ) = a[ j ];
+                        AT( j, numcon ) = a[ j ];
+                    }
+
+                    solve_dense( AA, dlocal, bb, k );
+                    for ( int j = 0; j < numcon; ++j ) dlam[ j ] = dlocal[ j ];
+                    dz = dlocal[ numcon ];
+
+                    for ( int i = 0; i < numvar; ++i )
+                    {
+                        dx[ i ] = -delx[ i ] / diagx[ i ];
+                        for ( int j = 0; j < numcon; ++j ) dx[ i ] -= ( GG[ j ][ i ] * dlam[ j ] ) / diagx[ i ];
+                    }
+                }
+                else
+                {
+                    int    k  = numvar + 1;
+                    auto   AT = [ & ]( int i2, int j2 ) -> double& { return AA[ i2 * k + j2 ]; };
+
+                    double azz = zet / z;
+                    for ( int j = 0; j < numcon; ++j )
+                    {
+                        diaglamyiinv[ j ] = 1.0 / diaglamyi[ j ];
+                        dellamyi[ j ]     = dellam[ j ] + dely[ j ] / diagy[ j ];
+                        azz += a[ j ] * a[ j ] / diaglamyi[ j ];
+                    }
+                    AT( numvar, numvar ) = azz;
+
+                    for ( int i = 0; i < numvar; ++i )
+                    {
+                        for ( int ii = 0; ii < numvar; ++ii )
+                        {
+                            double sum = 0.0;
+                            for ( int j = 0; j < numcon; ++j ) sum += GG[ j ][ i ] * GG[ j ][ ii ] * diaglamyiinv[ j ];
+                            AT( i, ii ) = sum;
+                        }
+                        AT( i, i ) += diagx[ i ];
+                        double col = 0.0;
+                        for ( int j = 0; j < numcon; ++j ) col -= GG[ j ][ i ] * a[ j ] / diaglamyi[ j ];
+                        AT( numvar, i ) = col;
+                        AT( i, numvar ) = col;
+                        bb[ i ]         = -delx[ i ];
+                        for ( int j = 0; j < numcon; ++j ) bb[ i ] -= GG[ j ][ i ] * dellamyi[ j ] / diaglamyi[ j ];
+                    }
+                    bb[ numvar ] = -delz;
+                    for ( int j = 0; j < numcon; ++j ) bb[ numvar ] += a[ j ] * dellamyi[ j ] / diaglamyi[ j ];
+
+                    solve_dense( AA, dlocal, bb, k );
+                    for ( int i = 0; i < numvar; ++i ) dx[ i ] = dlocal[ i ];
+                    dz = dlocal[ numvar ];
+
+                    for ( int j = 0; j < numcon; ++j )
+                    {
+                        dlam[ j ] = -dz * a[ j ] / diaglamyi[ j ] + dellamyi[ j ] / diaglamyi[ j ];
+                        for ( int i = 0; i < numvar; ++i ) dlam[ j ] += GG[ j ][ i ] * dx[ i ] / diaglamyi[ j ];
+                    }
+                }
+
+                dzet = -zet + epsi / z - zet * dz / z;
+
+                double stmxx   = -1.0e99;
+                double stmalfa = -1.0e99;
+                double stmbeta = -1.0e99;
+
+                stmxx = mx( stmxx, -1.01 * dz / z );
+                stmxx = mx( stmxx, -1.01 * dzet / zet );
+
+                for ( int i = 0; i < numvar; ++i )
+                {
+                    dxsi[ i ] = -xsi[ i ] + epsi / ( x[ i ] - alfa[ i ] ) - ( xsi[ i ] * dx[ i ] ) / ( x[ i ] - alfa[ i ] );
+                    deta[ i ] = -eta[ i ] + epsi / ( beta[ i ] - x[ i ] ) + ( eta[ i ] * dx[ i ] ) / ( beta[ i ] - x[ i ] );
+
+                    stmxx   = mx( stmxx, -1.01 * dxsi[ i ] / xsi[ i ] );
+                    stmxx   = mx( stmxx, -1.01 * deta[ i ] / eta[ i ] );
+                    stmalfa = mx( stmalfa, -1.01 * dx[ i ] / ( x[ i ] - alfa[ i ] ) );
+                    stmbeta = mx( stmbeta, 1.01 * dx[ i ] / ( beta[ i ] - x[ i ] ) );
+                }
+
+                for ( int j = 0; j < numcon; ++j )
+                {
+                    dy[ j ]  = -dely[ j ] / diagy[ j ] + dlam[ j ] / diagy[ j ];
+                    dmu[ j ] = -mu[ j ] + epsi / y[ j ] - ( mu[ j ] * dy[ j ] ) / y[ j ];
+                    ds[ j ]  = -s[ j ] + epsi / lam[ j ] - ( s[ j ] * dlam[ j ] ) / lam[ j ];
+
+                    stmxx = mx( stmxx, -1.01 * dy[ j ] / y[ j ] );
+                    stmxx = mx( stmxx, -1.01 * dlam[ j ] / lam[ j ] );
+                    stmxx = mx( stmxx, -1.01 * dmu[ j ] / mu[ j ] );
+                    stmxx = mx( stmxx, -1.01 * ds[ j ] / s[ j ] );
+                }
+
+                double stmalbe   = mx( stmalfa, stmbeta );
+                double stmalbexx = mx( stmalbe, stmxx );
+                double stminv    = mx( stmalbexx, 1.0 );
+                double steg      = 1.0 / stminv;
+
+                double zold   = z;
+                double zetold = zet;
+                for ( int i = 0; i < numvar; ++i ) { xold[ i ] = x[ i ]; xsiold[ i ] = xsi[ i ]; etaold[ i ] = eta[ i ]; }
+                for ( int j = 0; j < numcon; ++j ) { yold[ j ] = y[ j ]; lamold[ j ] = lam[ j ]; muold[ j ] = mu[ j ]; sold[ j ] = s[ j ]; }
+
+                int    itto    = 0;
+                double resinew = 2.0 * residunorm;
+                double resimax = residumax;
+
+                while ( resinew > residunorm && itto < 50 )
+                {
+                    itto++;
+                    resinew = 0.0;
+                    resimax = -1.0;
+
+                    z   = zold + steg * dz;
+                    zet = zetold + steg * dzet;
+                    for ( int i = 0; i < numvar; ++i )
+                    {
+                        x[ i ]   = xold[ i ] + steg * dx[ i ];
+                        xsi[ i ] = xsiold[ i ] + steg * dxsi[ i ];
+                        eta[ i ] = etaold[ i ] + steg * deta[ i ];
+                    }
+                    for ( int j = 0; j < numcon; ++j )
+                    {
+                        y[ j ]   = yold[ j ] + steg * dy[ j ];
+                        lam[ j ] = lamold[ j ] + steg * dlam[ j ];
+                        mu[ j ]  = muold[ j ] + steg * dmu[ j ];
+                        s[ j ]   = sold[ j ] + steg * ds[ j ];
+                        gvec[ j ] = 0.0;
+                    }
+
+                    for ( int i = 0; i < numvar; ++i )
+                    {
+                        double ux1    = upp[ i ] - x[ i ];
+                        double xl1    = x[ i ] - low[ i ];
+                        double ux2    = ux1 * ux1;
+                        double xl2    = xl1 * xl1;
+                        double uxinv1 = 1.0 / ux1;
+                        double xlinv1 = 1.0 / xl1;
+
+                        double plam = p0[ i ];
+                        for ( int j = 0; j < numcon; ++j ) plam += P[ j ][ i ] * lam[ j ];
+                        double qlam = q0[ i ];
+                        for ( int j = 0; j < numcon; ++j ) qlam += Q[ j ][ i ] * lam[ j ];
+
+                        double dpsidx = plam / ux2 - qlam / xl2;
+                        double rex    = dpsidx - xsi[ i ] + eta[ i ];
+                        double rexsi  = xsi[ i ] * ( x[ i ] - alfa[ i ] ) - epsi;
+                        double reeta  = eta[ i ] * ( beta[ i ] - x[ i ] ) - epsi;
+
+                        for ( int j = 0; j < numcon; ++j ) gvec[ j ] += P[ j ][ i ] * uxinv1 + Q[ j ][ i ] * xlinv1;
+
+                        resinew += rex * rex;     resimax = mx( resimax, std::abs( rex ) );
+                        resinew += rexsi * rexsi; resimax = mx( resimax, std::abs( rexsi ) );
+                        resinew += reeta * reeta; resimax = mx( resimax, std::abs( reeta ) );
+                    }
+
+                    rez   = a0 - zet;
+                    rezet = zet * z - epsi;
+                    for ( int j = 0; j < numcon; ++j )
+                    {
+                        double rey   = c[ j ] + d[ j ] * y[ j ] - mu[ j ] - lam[ j ];
+                        double relam = gvec[ j ] - z * a[ j ] - y[ j ] + s[ j ] - b[ j ];
+                        double remu  = mu[ j ] * y[ j ] - epsi;
+                        double res   = lam[ j ] * s[ j ] - epsi;
+                        rez -= a[ j ] * lam[ j ];
+
+                        resinew += rey * rey;     resimax = mx( resimax, std::abs( rey ) );
+                        resinew += relam * relam; resimax = mx( resimax, std::abs( relam ) );
+                        resinew += remu * remu;   resimax = mx( resimax, std::abs( remu ) );
+                        resinew += res * res;     resimax = mx( resimax, std::abs( res ) );
+                    }
+                    resinew += rez * rez;     resimax = mx( resimax, std::abs( rez ) );
+                    resinew += rezet * rezet; resimax = mx( resimax, std::abs( rezet ) );
+                    resinew = std::sqrt( resinew );
+                    steg    = steg / 2.0;
+                }
+
+                residunorm = resinew;
+                residumax  = resimax;
+                steg *= 2.0;
+            }
+            epsi *= 0.1;
+        }
+
+        zmma   = z;
+        zetmma = zet;
+        for ( int i = 0; i < numvar; ++i ) xmma[ i ] = x[ i ];
+    }
+
+    //------------------------------------------------------------------------------
+
+    int
+    Algorithm_MMA::mma_solve()
+    {
+        this->mma_initialize();
+
+        int iter  = 0;
+        int istop = 0;
+        int nfunc = 0;
+        int nsens = 0;
+
+        // enforce bounds and validate
+        int error1 = 0, error2 = 0;
+        for ( int i = 0; i < mNumVar; ++i )
+        {
+            xval[ i ] = mx( mn( xval[ i ], xmax[ i ] ), xmin[ i ] );
+            if ( std::abs( xmax[ i ] - xmin[ i ] ) < 1e-18 ) error1 = 1;
+            if ( xmax[ i ] <= xmin[ i ] ) error2 = 1;
+        }
+        MORIS_ERROR( error1 == 0, "Native MMA: upper and lower bounds of some variables are numerically identical." );
+        MORIS_ERROR( error2 == 0, "Native MMA: upper bound is smaller or equal to lower bound for some variables." );
+
+        // initial evaluation
+        this->func( xval.data(), f0val, fval );
+        this->grad( xval.data() );
+        nfunc++; nsens++;
+
+        // initialize raa0 and raa
+        if ( mMaxInnerIter )
+        {
+            raa0 = 1.0;
+            for ( int j = 0; j < mNumCon; ++j ) raa[ j ] = 1.0;
+        }
+        else
+        {
+            raa0 = 1.0e-5;
+            for ( int j = 0; j < mNumCon; ++j ) raa[ j ] = 1.0e-5;
+        }
+        double sclraa = 0.1 / mNumVar;
+        for ( int i = 0; i < mNumVar; ++i )
+        {
+            raa0 += sclraa * std::abs( df0dx[ i ] ) / ( xmax[ i ] - xmin[ i ] );
+            for ( int j = 0; j < mNumCon; ++j ) raa[ j ] += sclraa * std::abs( dfdx[ j ][ i ] ) / ( xmax[ i ] - xmin[ i ] );
+        }
+
+        // constraint penalty c_j
+        double penFac = ( mPenalty < 0 ) ? std::abs( f0val ) : mPenalty;
+        for ( int j = 0; j < mNumCon; ++j ) c[ j ] = penFac;
+
+        real tKKTrefres = -1.0;
+
+        while ( iter < mMaxIterations && istop == 0 )
+        {
+            iter++;
+
+            mMoveScale = 1.0;
+            this->asymp( iter );
+            this->gcmmasub( iter );
+
+            this->func( xmma.data(), f0valnew, fvalnew );
+            nfunc++;
+
+            // NaN guard: a non-finite trial criterion means the forward evaluation failed -- almost
+            // always an XTK decomposition failure where the moving interface's cut spans two HMR
+            // refinement levels ("not all child meshes on the same level"), which poisons every IQI
+            // integral (including the geometric volume/perimeter). Reject the step and shrink the
+            // move limit, re-solving until the criteria are finite. This is guaranteed to recover:
+            // as the move limit -> 0 the trial design -> xval, which was finite when committed.
+            int tBacktrack          = 0;
+            const int tMaxBacktrack = 15;
+            while ( !this->criteria_finite() && tBacktrack < tMaxBacktrack )
+            {
+                tBacktrack++;
+                mMoveScale *= 0.5;
+                MORIS_LOG_INFO( "Native MMA iter %d: non-finite criteria -- likely XTK decomposition failure "
+                                "(interface cut spans different HMR refinement levels). Rejecting step; "
+                                "move limit x%.4g (backtrack %d/%d).",
+                        (int)iter, mMoveScale, tBacktrack, tMaxBacktrack );
+                this->gcmmasub( iter );
+                this->func( xmma.data(), f0valnew, fvalnew );
+                nfunc++;
+            }
+            if ( !this->criteria_finite() )
+            {
+                // could not recover: hold the previous (finite) design and continue
+                MORIS_LOG_INFO( "Native MMA iter %d: criteria still non-finite after %d backtracks; "
+                                "holding previous design and continuing.",
+                        (int)iter, tMaxBacktrack );
+                continue;
+            }
+            // keep the (possibly shrunk) move limit for the conservatism loop this iteration;
+            // it is reset to 1.0 at the top of the next outer iteration.
+
+            int conserv = 1;
+            if ( ( f0app + epsimin ) < f0valnew ) conserv = 0;
+            for ( int j = 0; j < mNumCon; ++j )
+                if ( ( fapp[ j ] + epsimin ) < fvalnew[ j ] ) conserv = 0;
+
+            int innerit = 0;
+            if ( conserv == 0 )
+            {
+                while ( conserv == 0 && innerit < mMaxInnerIter )
+                {
+                    innerit++;
+                    this->raaupdate();
+                    this->gcmmasub( iter );
+                    this->func( xmma.data(), f0valnew, fvalnew );
+                    nfunc++;
+
+                    conserv = 1;
+                    if ( ( f0app + epsimin ) < f0valnew ) conserv = 0;
+                    for ( int j = 0; j < mNumCon; ++j )
+                        if ( ( fapp[ j ] + epsimin ) < fvalnew[ j ] ) conserv = 0;
+                }
+            }
+
+            // advance design. In reinit mode commit the redistanced design (mLastRedistanced holds
+            // the redistance of the accepted xmma); otherwise commit the raw subproblem solution.
+            const bool tUseRedist = mReinitHook && (int)mLastRedistanced.size() == mNumVar;
+            for ( int i = 0; i < mNumVar; ++i )
+            {
+                xold2[ i ] = xold1[ i ];
+                xold1[ i ] = xval[ i ];
+                xval[ i ]  = tUseRedist ? mLastRedistanced[ i ] : xmma[ i ];
+            }
+            f0val = f0valnew;
+            for ( int j = 0; j < mNumCon; ++j ) fval[ j ] = fvalnew[ j ];
+
+            this->grad( xval.data() );
+            nsens++;
+
+            istop = this->kktcheck( tKKTrefres );
+        }
+
+        return ( iter < mMaxIterations ) ? 0 : 1;
+    }
+}    // namespace moris::opt

--- a/projects/OPT/src/cl_OPT_Algorithm_MMA.cpp
+++ b/projects/OPT/src/cl_OPT_Algorithm_MMA.cpp
@@ -88,6 +88,29 @@ namespace moris::opt
     void
     Algorithm_MMA::func( double* aX, real& aF0, std::vector< double >& aF )
     {
+        // Guard: the subproblem can overflow on a degenerate evaluation (huge objective/
+        // gradient jump from a near-degenerate XFEM cut) and produce a non-finite trial
+        // design. Evaluating it would compute garbage criteria and trip the gradient-
+        // consistency assert. Request an optimizer restart instead (the solve loop checks
+        // the flag after every func call and exits; the Manager then re-initializes from
+        // the current design) and return the last evaluated objective and constraints.
+        for ( int i = 0; i < mNumVar; ++i )
+        {
+            if ( !std::isfinite( aX[ i ] ) )
+            {
+                MORIS_LOG_WARNING( "Native MMA produced a non-finite design vector; requesting optimizer restart." );
+
+                mProblem->request_restart();
+
+                aF0 = this->get_objectives()( 0 );
+
+                const Matrix< DDRMat >& tLastCon = this->get_constraints();
+                for ( int j = 0; j < mNumCon; ++j ) aF[ j ] = tLastCon( j );
+
+                return;
+            }
+        }
+
         Vector< real > tADVs( mNumVar );
         for ( int i = 0; i < mNumVar; ++i ) tADVs( i ) = aX[ i ];
 
@@ -844,6 +867,19 @@ namespace moris::opt
 
         // initial evaluation
         this->func( xval.data(), f0val, fval );
+
+        // The workflow can request an optimization restart during a criteria evaluation
+        // (adaptive remeshing or a scheduled reinitialization invalidates the current ADV
+        // vector). Mirror the TPL GCMMA wrapper: exit the solve loop immediately so the
+        // Manager re-initializes the problem (fresh mesh + ADVs) and re-enters solve.
+        // Backtracking instead would iterate on a stale design AND on frozen sensitivities
+        // (the pending-restart flag makes the criteria interface return cached gradients).
+        if ( mProblem->restart_optimization() )
+        {
+            MORIS_LOG_INFO( "Native MMA: optimization restart requested during initial evaluation; exiting solve loop." );
+            return istop;
+        }
+
         this->grad( xval.data() );
         nfunc++; nsens++;
 
@@ -882,6 +918,14 @@ namespace moris::opt
             this->func( xmma.data(), f0valnew, fvalnew );
             nfunc++;
 
+            // restart takes precedence over the NaN backtrack: the workflow has invalidated
+            // the current design/mesh and the Manager must re-initialize the problem
+            if ( mProblem->restart_optimization() )
+            {
+                MORIS_LOG_INFO( "Native MMA iter %d: optimization restart requested; exiting solve loop.", (int)iter );
+                return istop;
+            }
+
             // NaN guard: a non-finite trial criterion means the forward evaluation failed -- almost
             // always an XTK decomposition failure where the moving interface's cut spans two HMR
             // refinement levels ("not all child meshes on the same level"), which poisons every IQI
@@ -901,6 +945,12 @@ namespace moris::opt
                 this->gcmmasub( iter );
                 this->func( xmma.data(), f0valnew, fvalnew );
                 nfunc++;
+
+                if ( mProblem->restart_optimization() )
+                {
+                    MORIS_LOG_INFO( "Native MMA iter %d: optimization restart requested during backtrack; exiting solve loop.", (int)iter );
+                    return istop;
+                }
             }
             if ( !this->criteria_finite() )
             {
@@ -928,6 +978,12 @@ namespace moris::opt
                     this->gcmmasub( iter );
                     this->func( xmma.data(), f0valnew, fvalnew );
                     nfunc++;
+
+                    if ( mProblem->restart_optimization() )
+                    {
+                        MORIS_LOG_INFO( "Native MMA iter %d: optimization restart requested during inner iteration; exiting solve loop.", (int)iter );
+                        return istop;
+                    }
 
                     conserv = 1;
                     if ( ( f0app + epsimin ) < f0valnew ) conserv = 0;

--- a/projects/OPT/src/cl_OPT_Algorithm_MMA.cpp
+++ b/projects/OPT/src/cl_OPT_Algorithm_MMA.cpp
@@ -102,7 +102,7 @@ namespace moris::opt
 
                 mProblem->request_restart();
 
-                aF0 = this->get_objectives()( 0 );
+                aF0 = mObjScale * this->get_objectives()( 0 );
 
                 const Matrix< DDRMat >& tLastCon = this->get_constraints();
                 for ( int j = 0; j < mNumCon; ++j ) aF[ j ] = tLastCon( j );
@@ -116,7 +116,7 @@ namespace moris::opt
 
         this->compute_design_criteria( tADVs );
 
-        aF0 = this->get_objectives()( 0 );
+        aF0 = mObjScale * this->get_objectives()( 0 );
 
         const Matrix< DDRMat >& tCon = this->get_constraints();
         for ( int j = 0; j < mNumCon; ++j ) aF[ j ] = tCon( j );
@@ -147,7 +147,28 @@ namespace moris::opt
         const Matrix< DDRMat >& tObjGrad = this->get_objective_gradients();      // 1 x numvar
         const Matrix< DDRMat >& tConGrad = this->get_constraint_gradients();     // numcon x numvar
 
-        for ( int i = 0; i < mNumVar; ++i ) df0dx[ i ] = tObjGrad( 0, i );
+        // Uniform objective scaling: engage only above the pathology threshold, quantized to
+        // decades, and re-book the stored objective value (currently in the previous scale)
+        // so the whole outer iteration is consistent in the new scale.
+        real tRawMax = 0.0;
+        for ( int i = 0; i < mNumVar; ++i ) tRawMax = mx( tRawMax, std::abs( tObjGrad( 0, i ) ) );
+
+        real tNewScale = 1.0;
+        if ( tRawMax > sObjGradEngage )
+        {
+            // smallest power of ten that brings tRawMax at or below the target
+            tNewScale = std::pow( 10.0, -std::ceil( std::log10( tRawMax / sObjGradTarget ) ) );
+        }
+
+        if ( tNewScale != mObjScale )
+        {
+            MORIS_LOG_INFO( "Native MMA: objective scale -> %.1e (raw max|df0dx| = %.4e).",
+                    tNewScale, tRawMax );
+            f0val    *= tNewScale / mObjScale;
+            mObjScale = tNewScale;
+        }
+
+        for ( int i = 0; i < mNumVar; ++i ) df0dx[ i ] = mObjScale * tObjGrad( 0, i );
         for ( int j = 0; j < mNumCon; ++j )
             for ( int i = 0; i < mNumVar; ++i ) dfdx[ j ][ i ] = tConGrad( j, i );
     }
@@ -848,6 +869,9 @@ namespace moris::opt
     Algorithm_MMA::mma_solve()
     {
         this->mma_initialize();
+
+        // fresh solve (possibly after a restart): objective scale re-derives from the first grad()
+        mObjScale = 1.0;
 
         int iter  = 0;
         int istop = 0;

--- a/projects/OPT/src/cl_OPT_Algorithm_MMA.hpp
+++ b/projects/OPT/src/cl_OPT_Algorithm_MMA.hpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2022 University of Colorado
+ * Licensed under the MIT license. See LICENSE.txt file in the MORIS root for details.
+ *
+ *------------------------------------------------------------------------------------
+ *
+ * cl_OPT_Algorithm_MMA.hpp
+ *
+ * Native in-tree port of Svanberg's Globally Convergent Method of Moving Asymptotes
+ * (GCMMA, 2002). Ported from the canonical reference implementation github.com/kkmaute/gcmma
+ * (files mma.cpp/solve.cpp/asymp.cpp/gcmmasub.cpp/raaupdate.cpp/subsolve.cpp/kktcheck.cpp).
+ *
+ * Owning the outer loop in-tree (instead of linking the external TPL) lets MORIS update the
+ * design vector mid-iteration -- e.g. an in-place SDF redistance each step without a GCMMA
+ * restart. Variable names mirror the reference for line-by-line validation against the TPL.
+ */
+
+#ifndef MORIS_CL_OPT_ALGORITHM_MMA_HPP_
+#define MORIS_CL_OPT_ALGORITHM_MMA_HPP_
+
+#include <vector>
+
+#include "core.hpp"
+#include "cl_OPT_Algorithm.hpp"
+#include "cl_Parameter_List.hpp"
+#include "cl_OPT_Problem.hpp"
+
+namespace moris::opt
+{
+    class Algorithm_MMA : public Algorithm
+    {
+      private:
+        // ---- user parameters (mirror the GCMMA parameter list) ----
+        bool mPrint        = false;
+        sint mMaxInnerIter = 0;      ///< max inner conservative cycles (maxinnerit)
+        real mNormDrop     = 1e-4;   ///< KKT relative-residual accuracy (acc)
+        real mAsympAdapt0  = 0.5;    ///< initial asymptote spread factor (saFac)
+        real mAsympShrink  = 0.7;    ///< oscillation shrink factor (sbFac)
+        real mAsympExpand  = 1.2;    ///< monotone expand factor (scFac)
+        real mStepSize     = 0.01;   ///< move limit fraction (dstep)
+        real mPenalty      = 100.0;  ///< constraint penalty c_j (penal; <0 => |f0|)
+
+        // ---- problem dimensions ----
+        int mNumVar = 0;   ///< number of design variables (numvar)
+        int mNumCon = 0;   ///< number of constraints (numcon)
+
+        // ---- algorithm scalars (reference names) ----
+        real epsimin = 0.0;
+        real raa0eps = 1.0e-7;
+        real a0      = 1.0;
+        real raa0    = 0.0;
+        real r0      = 0.0;
+        real f0val   = 0.0;
+        real f0valnew = 0.0;
+        real f0app   = 0.0;
+        real z = 0.0, zet = 0.0, zmma = 0.0, zetmma = 0.0;
+
+        // ---- 1D state, size numvar ----
+        std::vector< double > xval, xold1, xold2, xmax, xmin;
+        std::vector< double > low, upp, alfa, beta;
+        std::vector< double > p0, q0, df0dx;
+        // subsolve working arrays (size numvar, dx is numvar+1)
+        std::vector< double > x, xold, delx, diagx, diagxinv, xmma, dx;
+        std::vector< double > xsi, xsiold, dxsi, eta, etaold, deta;
+
+        // ---- 1D state, size numcon ----
+        std::vector< double > fval, fvalnew, a, b, c, d, r, raa, fapp, gvec;
+        std::vector< double > y, yold, dy, dely, diagy, diagyinv;
+        std::vector< double > lam, lamold, dlam, dellam, dellamyi;          // dlam is numcon+1
+        std::vector< double > diaglam, diaglamyi, diaglamyiinv;
+        std::vector< double > mu, muold, dmu, s, sold, ds;
+
+        // ---- 2D state, numcon x numvar ----
+        std::vector< std::vector< double > > P, Q, GG, dfdx;
+
+        // ---- dense Newton system (size min(numcon,numvar)+1) ----
+        std::vector< double > AA;   ///< flat row-major k x k
+        std::vector< double > bb;   ///< rhs, size k
+
+        // ---- optional in-place reinitialization hook ----
+        bool mReinitHook = false;   ///< if true, call Problem reinit on xval each outer iteration
+        std::vector< double > mLastRedistanced;   ///< redistanced ADVs from the most recent func() eval
+                                                  ///< (kept separate so xmma stays the raw subproblem
+                                                  ///< solution for raaupdate/conservatism); committed to xval
+
+        // ---- NaN guard ----
+        real mMoveScale = 1.0;      ///< move-limit multiplier; shrunk while backtracking off a bad step
+
+        /** true if the current trial criteria (f0valnew, fvalnew) are all finite */
+        bool criteria_finite() const;
+
+        // ================= helpers (ports of the reference functions) =================
+
+        /** allocate/size all arrays and set epsimin, a0, a, d (port of initialize.cpp) */
+        void mma_initialize();
+
+        /**
+         * Evaluate objective+constraints at x via the inherited criteria call (port of func_wrap).
+         * aX is mutable: when the in-place reinit hook is active, any redistance the workflow
+         * applies to the ADV vector during criteria evaluation is written back into aX, so the
+         * redistanced design persists in the optimizer state (no GCMMA restart needed).
+         */
+        void func( double* aX, real& aF0, std::vector< double >& aF );
+
+        /** evaluate gradients at x via inherited criteria-gradient call (port of grad_wrap) */
+        void grad( const double* aX );
+
+        /** update asymptotes low/upp and shrink raa (port of asymp.cpp) */
+        void asymp( int aIter );
+
+        /** build conservative convex approximation, solve subproblem, eval f0app/fapp (gcmmasub.cpp) */
+        void gcmmasub( int aIter );
+
+        /** increase raa0/raa until conservative (raaupdate.cpp) */
+        void raaupdate();
+
+        /** primal-dual interior-point solve of the MMA subproblem (subsolve.cpp) */
+        void subsolve();
+
+        /** KKT residual convergence test; returns 1 if converged (kktcheck.cpp) */
+        int kktcheck( real& aKKTrefres );
+
+        /** small dense LU solve with partial pivoting: solves A(k x k) x = b in place of dgesv */
+        static void solve_dense( std::vector< double >& aA, std::vector< double >& aX,
+                const std::vector< double >& aB, int aN );
+
+        inline double mx( double a, double b ) { return a > b ? a : b; }
+        inline double mn( double a, double b ) { return a < b ? a : b; }
+
+      public:
+        /** Constructor */
+        explicit Algorithm_MMA( const moris::Parameter_List& aParameterList );
+
+        /** Destructor */
+        ~Algorithm_MMA() override;
+
+        /**
+         * @brief Solve the optimization problem with the native GCMMA
+         */
+        uint solve(
+                uint                                   aCurrentOptAlgInd,
+                std::shared_ptr< moris::opt::Problem > aOptProb ) override;
+
+        /** Run the GCMMA outer loop on proc 0 (port of solve.cpp) */
+        int mma_solve();
+    };
+}    // namespace moris::opt
+
+#endif /* MORIS_CL_OPT_ALGORITHM_MMA_HPP_ */

--- a/projects/OPT/src/cl_OPT_Algorithm_MMA.hpp
+++ b/projects/OPT/src/cl_OPT_Algorithm_MMA.hpp
@@ -86,6 +86,20 @@ namespace moris::opt
         // ---- NaN guard ----
         real mMoveScale = 1.0;      ///< move-limit multiplier; shrunk while backtracking off a bad step
 
+        // ---- objective scaling (degenerate-evaluation safeguard) ----
+        // GCMMA assumes an O(1-100) objective (Svanberg's own scaling recommendation). Degenerate
+        // XFEM cuts can hand back gradients of 1e10+, which overflow the subproblem's interior-point
+        // arithmetic into NaN iterates. When max|df0dx| exceeds the target, the objective and its
+        // gradient are scaled UNIFORMLY for the current outer iteration -- this preserves the descent
+        // direction exactly (unlike per-entry clipping, which distorts it) and returns the subproblem
+        // to its proven operating range. The stored objective value is re-booked at each grad() call
+        // so all quantities within an outer iteration share one consistent scale.
+        real mObjScale             = 1.0;      ///< current uniform objective scale (1 = unscaled)
+        static constexpr real sObjGradEngage = 1.0e9;    ///< scale only above this -- the solver demonstrably
+                                                         ///< handles 1e8 raw and overflows ~1e10; engaging in
+                                                         ///< proven regimes needlessly perturbs the trajectory
+        static constexpr real sObjGradTarget = 1.0e8;    ///< decade-quantized scale brings max into (1e7, 1e8]
+
         /** true if the current trial criteria (f0valnew, fvalnew) are all finite */
         bool criteria_finite() const;
 

--- a/projects/OPT/src/cl_OPT_Criteria_Interface.hpp
+++ b/projects/OPT/src/cl_OPT_Criteria_Interface.hpp
@@ -81,6 +81,17 @@ namespace moris::opt
             return mInitializeOptimizationRestart;
         }
 
+        /**
+         * requests a restart of the optimization (e.g. when an optimization algorithm
+         * produces a non-finite design and needs to be re-initialized from the current
+         * design); the flag is cleared by the workflow on the restart's initialize
+         */
+        void
+        request_restart_optimization()
+        {
+            mInitializeOptimizationRestart = true;
+        }
+
         void
         set_reinitialize_iter( uint aReinitializeIter )
         {

--- a/projects/OPT/src/cl_OPT_Manager.cpp
+++ b/projects/OPT/src/cl_OPT_Manager.cpp
@@ -14,6 +14,7 @@
 #include "fn_OPT_create_problem.hpp"
 #include "fn_OPT_create_interface.hpp"
 #include "fn_OPT_create_algorithm.hpp"
+#include "cl_Communication_Tools.hpp"
 
 // Logger package
 #include "cl_Logger.hpp"
@@ -89,7 +90,13 @@ namespace moris::opt
             uint aI,
             uint aOptIteration )
     {
-        if ( mProblem->restart_optimization() )
+        // The restart request can originate on processor 0 only (the optimization algorithm's
+        // solve loop -- e.g. the non-finite-iterate guards -- runs on rank 0 while the other
+        // ranks are in dummy_solve), but Problem::initialize() below is collective. Synchronize
+        // the decision so all processors take the same branch; one-sided entry deadlocks.
+        bool tRestart = all_lor( mProblem->restart_optimization() );
+
+        if ( tRestart )
         {
             mAlgorithms( aI )->set_restart_index( aOptIteration - 1 );
 

--- a/projects/OPT/src/cl_OPT_Problem.cpp
+++ b/projects/OPT/src/cl_OPT_Problem.cpp
@@ -73,6 +73,24 @@ namespace moris::opt
         // Log number of optimization variables
         MORIS_LOG_SPEC( "Number of optimization variables", mADVs.size() );
 
+        // Diagnostic: non-finite entries handed back by the interface poison the optimizer
+        // (NaN ADVs make every downstream consistency check fail). Detect them at the source.
+        if ( par_rank() == 0 )
+        {
+            uint tNanADVs    = 0;
+            uint tNanBounds  = 0;
+            for ( uint iADV = 0; iADV < mADVs.size(); iADV++ )
+            {
+                if ( !std::isfinite( mADVs( iADV ) ) ) tNanADVs++;
+                if ( !std::isfinite( mLowerBounds( iADV ) ) || !std::isfinite( mUpperBounds( iADV ) ) ) tNanBounds++;
+            }
+            if ( tNanADVs > 0 || tNanBounds > 0 )
+            {
+                MORIS_LOG_WARNING( "Problem::initialize - non-finite entries after interface initialize: %u ADVs, %u bounds (of %zu).",
+                        tNanADVs, tNanBounds, mADVs.size() );
+            }
+        }
+
         MORIS_ERROR( mADVs.size() == mLowerBounds.size() and mADVs.size() == mUpperBounds.size(),
                 "ADVs and its lower and upper bound vectors need to have same length.\n" );
 

--- a/projects/OPT/src/cl_OPT_Problem.cpp
+++ b/projects/OPT/src/cl_OPT_Problem.cpp
@@ -22,6 +22,10 @@
 
 #include "fn_stringify_matrix.hpp"
 
+#include <algorithm>
+#include <vector>
+#include <cmath>
+
 namespace moris::opt
 {
 
@@ -260,6 +264,143 @@ namespace moris::opt
 
             MORIS_ASSERT( mConstraintGradient.n_rows() == mNumConstraints and mConstraintGradient.n_cols() == mADVs.size(),
                     "Problem::compute_design_criteria_gradients  - gradient of constraint matrix has incorrect size.\n." );
+
+            // ----- Gradient explosion detection and per-ADV clipping -----
+            real tObjGradNorm = norm( mObjectiveGradient );
+            real tConGradNorm = norm( mConstraintGradient );
+
+            bool tGradClipped = false;
+
+            // ----- Self-calibrating gradient-explosion clip (every iteration) -----
+            // Small XFEM cut cells make a few dIQI/dADV entries explode by many orders of magnitude
+            // (dIQI/dPDV ~ 1/cell_volume as the interface nears a background node). The design
+            // gradient is bimodal: most B-spline coeffs are EXACTLY 0 (inactive, no interface in
+            // their support), a band is healthy active sensitivity, and a few explode. Clip each
+            // entry to mGradClipFactor x the MEDIAN of the NONZERO entries -- the active-band scale.
+            // This is (a) self-calibrating from the current gradient, so it needs no "previous
+            // healthy" baseline -- dense seedings explode from iteration 1 and never establish one,
+            // which is why a relative-jump test (ratio > threshold) never fired and the raw 1e8
+            // gradient froze the design; and (b) immune to the inactive-zero floor that made a
+            // P90-of-ALL-entries reference collapse to ~0 and crush the whole active gradient.
+            auto tActiveScale = []( const Matrix< DDRMat >& aGrad ) -> real {
+                std::vector< real > tNz;
+                tNz.reserve( aGrad.n_rows() * aGrad.n_cols() );
+                for ( uint ii = 0; ii < aGrad.n_rows(); ++ii )
+                    for ( uint jj = 0; jj < aGrad.n_cols(); ++jj )
+                    {
+                        real tv = std::abs( aGrad( ii, jj ) );
+                        if ( tv > 0.0 ) tNz.push_back( tv );
+                    }
+                if ( tNz.empty() ) return 0.0;
+                uint tMid = tNz.size() / 2;
+                std::nth_element( tNz.begin(), tNz.begin() + tMid, tNz.end() );
+                return tNz[ tMid ];
+            };
+
+            real tObjClipVal = mGradClipFactor * tActiveScale( mObjectiveGradient );
+            real tConClipVal = mGradClipFactor * tActiveScale( mConstraintGradient );
+
+            // degenerate (all-zero) gradient: disable clipping for it
+            if ( !( tObjClipVal > 0.0 ) ) tObjClipVal = 1.0e30;
+            if ( !( tConClipVal > 0.0 ) ) tConClipVal = 1.0e30;
+
+            uint tObjClipCount = 0;
+            uint tConClipCount = 0;
+
+            for ( uint j = 0; j < mADVs.size(); j++ )
+            {
+                for ( uint i = 0; i < mObjectiveGradient.n_rows(); i++ )
+                {
+                    if ( std::abs( mObjectiveGradient( i, j ) ) > tObjClipVal )
+                    {
+                        real tSign                  = ( mObjectiveGradient( i, j ) > 0.0 ) ? 1.0 : -1.0;
+                        mObjectiveGradient( i, j )  = tSign * tObjClipVal;
+                        tObjClipCount++;
+                    }
+                }
+                for ( uint i = 0; i < mConstraintGradient.n_rows(); i++ )
+                {
+                    if ( std::abs( mConstraintGradient( i, j ) ) > tConClipVal )
+                    {
+                        real tSign                  = ( mConstraintGradient( i, j ) > 0.0 ) ? 1.0 : -1.0;
+                        mConstraintGradient( i, j ) = tSign * tConClipVal;
+                        tConClipCount++;
+                    }
+                }
+            }
+
+            tGradClipped = ( tObjClipCount + tConClipCount ) > 0;
+
+            if ( tGradClipped )
+            {
+                MORIS_LOG_WARNING(
+                        "Gradient clip: %u obj + %u con entries clipped (clip_val = %.4e / %.4e, "
+                        "raw obj_norm = %.4e).",
+                        tObjClipCount,
+                        tConClipCount,
+                        tObjClipVal,
+                        tConClipVal,
+                        tObjGradNorm );
+            }
+
+            // ----- Gradient diagnostics logging -----
+            real tObjGradMax = 0.0;
+            real tConGradMax = 0.0;
+            {
+                uint tAtLower = 0;
+                uint tAtUpper = 0;
+
+                for ( uint j = 0; j < mADVs.size(); j++ )
+                {
+                    // Max absolute gradient entry
+                    for ( uint i = 0; i < mObjectiveGradient.n_rows(); i++ )
+                    {
+                        tObjGradMax = std::max( tObjGradMax, std::abs( mObjectiveGradient( i, j ) ) );
+                    }
+                    for ( uint i = 0; i < mConstraintGradient.n_rows(); i++ )
+                    {
+                        tConGradMax = std::max( tConGradMax, std::abs( mConstraintGradient( i, j ) ) );
+                    }
+
+                    // Bound saturation (ADV within 1e-10 of bound)
+                    if ( std::abs( mADVs( j ) - mLowerBounds( j ) ) < 1.0e-10 )
+                    {
+                        tAtLower++;
+                    }
+                    if ( std::abs( mADVs( j ) - mUpperBounds( j ) ) < 1.0e-10 )
+                    {
+                        tAtUpper++;
+                    }
+                }
+
+                MORIS_LOG_INFO(
+                    "GradDebug: obj_norm=%.4e  con_norm=%.4e  obj_max=%.4e  con_max=%.4e  at_lower=%u  at_upper=%u  n_advs=%zu",
+                    tObjGradNorm,
+                    tConGradNorm,
+                    tObjGradMax,
+                    tConGradMax,
+                    tAtLower,
+                    tAtUpper,
+                    mADVs.size() );
+            }
+
+            // Update the reference gradient for next-iteration explosion detection. CRITICAL:
+            // when clipping fired this iteration, do NOT adopt the (artificially shrunk) clipped
+            // norm as the reference. Doing so makes the clip threshold (mPrevObjGradNorm/sqrt(N))
+            // spiral toward zero over successive explosions, eventually clipping the *healthy*
+            // optimization gradient to ~0 and freezing the design at its initial topology. Keep the
+            // last healthy reference instead, so the clip caps explosive (small-cut-cell) ADVs at
+            // the healthy gradient scale while letting the legitimate gradient drive the design.
+            if ( !tGradClipped )
+            {
+                mPrevObjectiveGradient  = mObjectiveGradient;
+                mPrevConstraintGradient = mConstraintGradient;
+                mPrevObjGradNorm        = norm( mObjectiveGradient );
+                mPrevConGradNorm        = norm( mConstraintGradient );
+                mPrevObjGradMax         = tObjGradMax;    // healthy per-entry scale for absolute clip
+                mPrevConGradMax         = tConGradMax;
+            }
+            mHasPrevGradients = true;
         }
     }
 

--- a/projects/OPT/src/cl_OPT_Problem.cpp
+++ b/projects/OPT/src/cl_OPT_Problem.cpp
@@ -42,6 +42,12 @@ namespace moris::opt
 
         // Parameters: restart file name
         mRestartFile = aParameterList.get< std::string >( "restart_file" );
+
+        // Parameters: gradient-explosion clip factor; <= 0 disables the clip
+        if ( aParameterList.exists( "grad_clip_factor" ) )
+        {
+            mGradClipFactor = aParameterList.get< real >( "grad_clip_factor" );
+        }
     }
 
     // -------------------------------------------------------------------------------------------------------------
@@ -271,7 +277,7 @@ namespace moris::opt
 
             bool tGradClipped = false;
 
-            // ----- Self-calibrating gradient-explosion clip (every iteration) -----
+            // ----- Self-calibrating gradient-explosion clip (opt-in via grad_clip_factor) -----
             // Small XFEM cut cells make a few dIQI/dADV entries explode by many orders of magnitude
             // (dIQI/dPDV ~ 1/cell_volume as the interface nears a background node). The design
             // gradient is bimodal: most B-spline coeffs are EXACTLY 0 (inactive, no interface in
@@ -282,65 +288,70 @@ namespace moris::opt
             // which is why a relative-jump test (ratio > threshold) never fired and the raw 1e8
             // gradient froze the design; and (b) immune to the inactive-zero floor that made a
             // P90-of-ALL-entries reference collapse to ~0 and crush the whole active gradient.
-            auto tActiveScale = []( const Matrix< DDRMat >& aGrad ) -> real {
-                std::vector< real > tNz;
-                tNz.reserve( aGrad.n_rows() * aGrad.n_cols() );
-                for ( uint ii = 0; ii < aGrad.n_rows(); ++ii )
-                    for ( uint jj = 0; jj < aGrad.n_cols(); ++jj )
-                    {
-                        real tv = std::abs( aGrad( ii, jj ) );
-                        if ( tv > 0.0 ) tNz.push_back( tv );
-                    }
-                if ( tNz.empty() ) return 0.0;
-                uint tMid = tNz.size() / 2;
-                std::nth_element( tNz.begin(), tNz.begin() + tMid, tNz.end() );
-                return tNz[ tMid ];
-            };
-
-            real tObjClipVal = mGradClipFactor * tActiveScale( mObjectiveGradient );
-            real tConClipVal = mGradClipFactor * tActiveScale( mConstraintGradient );
-
-            // degenerate (all-zero) gradient: disable clipping for it
-            if ( !( tObjClipVal > 0.0 ) ) tObjClipVal = 1.0e30;
-            if ( !( tConClipVal > 0.0 ) ) tConClipVal = 1.0e30;
-
-            uint tObjClipCount = 0;
-            uint tConClipCount = 0;
-
-            for ( uint j = 0; j < mADVs.size(); j++ )
+            // The cap also flattens legitimately large sensitivities, so the clip is disabled
+            // unless explicitly requested (grad_clip_factor > 0).
+            if ( mGradClipFactor > 0.0 )
             {
-                for ( uint i = 0; i < mObjectiveGradient.n_rows(); i++ )
+                auto tActiveScale = []( const Matrix< DDRMat >& aGrad ) -> real {
+                    std::vector< real > tNz;
+                    tNz.reserve( aGrad.n_rows() * aGrad.n_cols() );
+                    for ( uint ii = 0; ii < aGrad.n_rows(); ++ii )
+                        for ( uint jj = 0; jj < aGrad.n_cols(); ++jj )
+                        {
+                            real tv = std::abs( aGrad( ii, jj ) );
+                            if ( tv > 0.0 ) tNz.push_back( tv );
+                        }
+                    if ( tNz.empty() ) return 0.0;
+                    uint tMid = tNz.size() / 2;
+                    std::nth_element( tNz.begin(), tNz.begin() + tMid, tNz.end() );
+                    return tNz[ tMid ];
+                };
+
+                real tObjClipVal = mGradClipFactor * tActiveScale( mObjectiveGradient );
+                real tConClipVal = mGradClipFactor * tActiveScale( mConstraintGradient );
+
+                // degenerate (all-zero) gradient: disable clipping for it
+                if ( !( tObjClipVal > 0.0 ) ) tObjClipVal = 1.0e30;
+                if ( !( tConClipVal > 0.0 ) ) tConClipVal = 1.0e30;
+
+                uint tObjClipCount = 0;
+                uint tConClipCount = 0;
+
+                for ( uint j = 0; j < mADVs.size(); j++ )
                 {
-                    if ( std::abs( mObjectiveGradient( i, j ) ) > tObjClipVal )
+                    for ( uint i = 0; i < mObjectiveGradient.n_rows(); i++ )
                     {
-                        real tSign                  = ( mObjectiveGradient( i, j ) > 0.0 ) ? 1.0 : -1.0;
-                        mObjectiveGradient( i, j )  = tSign * tObjClipVal;
-                        tObjClipCount++;
+                        if ( std::abs( mObjectiveGradient( i, j ) ) > tObjClipVal )
+                        {
+                            real tSign                  = ( mObjectiveGradient( i, j ) > 0.0 ) ? 1.0 : -1.0;
+                            mObjectiveGradient( i, j )  = tSign * tObjClipVal;
+                            tObjClipCount++;
+                        }
+                    }
+                    for ( uint i = 0; i < mConstraintGradient.n_rows(); i++ )
+                    {
+                        if ( std::abs( mConstraintGradient( i, j ) ) > tConClipVal )
+                        {
+                            real tSign                  = ( mConstraintGradient( i, j ) > 0.0 ) ? 1.0 : -1.0;
+                            mConstraintGradient( i, j ) = tSign * tConClipVal;
+                            tConClipCount++;
+                        }
                     }
                 }
-                for ( uint i = 0; i < mConstraintGradient.n_rows(); i++ )
+
+                tGradClipped = ( tObjClipCount + tConClipCount ) > 0;
+
+                if ( tGradClipped )
                 {
-                    if ( std::abs( mConstraintGradient( i, j ) ) > tConClipVal )
-                    {
-                        real tSign                  = ( mConstraintGradient( i, j ) > 0.0 ) ? 1.0 : -1.0;
-                        mConstraintGradient( i, j ) = tSign * tConClipVal;
-                        tConClipCount++;
-                    }
+                    MORIS_LOG_WARNING(
+                            "Gradient clip: %u obj + %u con entries clipped (clip_val = %.4e / %.4e, "
+                            "raw obj_norm = %.4e).",
+                            tObjClipCount,
+                            tConClipCount,
+                            tObjClipVal,
+                            tConClipVal,
+                            tObjGradNorm );
                 }
-            }
-
-            tGradClipped = ( tObjClipCount + tConClipCount ) > 0;
-
-            if ( tGradClipped )
-            {
-                MORIS_LOG_WARNING(
-                        "Gradient clip: %u obj + %u con entries clipped (clip_val = %.4e / %.4e, "
-                        "raw obj_norm = %.4e).",
-                        tObjClipCount,
-                        tConClipCount,
-                        tObjClipVal,
-                        tConClipVal,
-                        tObjGradNorm );
             }
 
             // ----- Gradient diagnostics logging -----

--- a/projects/OPT/src/cl_OPT_Problem.hpp
+++ b/projects/OPT/src/cl_OPT_Problem.hpp
@@ -159,6 +159,15 @@ namespace moris::opt
         }
 
         /**
+         * request a restart of the optimization (re-initializes the problem from the
+         * current design); used by algorithms to recover from non-finite iterates
+         */
+        void request_restart()
+        {
+            mInterface->request_restart_optimization();
+        }
+
+        /**
          * Checks that the constraints are given in the correct order (equality constraints first)
          *
          * @return bool, if order is correct

--- a/projects/OPT/src/cl_OPT_Problem.hpp
+++ b/projects/OPT/src/cl_OPT_Problem.hpp
@@ -32,6 +32,17 @@ namespace moris::opt
         Matrix< DDRMat > mObjectiveGradient;           // full gradient of the objectives with respect to the ADVs
         Matrix< DDRMat > mConstraintGradient;          // full gradient of the constraints with respect to the ADVs
 
+        // Gradient fallback: store previous iteration's gradients for explosion detection
+        Matrix< DDRMat > mPrevObjectiveGradient;       // previous iteration objective gradient
+        Matrix< DDRMat > mPrevConstraintGradient;      // previous iteration constraint gradient
+        real mPrevObjGradNorm  = 0.0;                  // previous objective gradient norm
+        real mPrevConGradNorm  = 0.0;                  // previous constraint gradient norm
+        real mPrevObjGradMax   = 0.0;                  // last HEALTHY max |objective gradient entry|
+        real mPrevConGradMax   = 0.0;                  // last HEALTHY max |constraint gradient entry|
+        bool mHasPrevGradients = false;                 // whether previous gradients are valid
+        real mGradExplosionRatio = 1.0e6;              // (legacy) norm ratio threshold, kept for diagnostics
+        real mGradClipFactor     = 20.0;               // clip entries above this x the median nonzero |gradient|
+
         std::string mRestartFile;                      // Restart file
 
         real mADVNormTolerance = 1e-12;                // Tolerance for determining whether ADV vector has changed

--- a/projects/OPT/src/cl_OPT_Problem.hpp
+++ b/projects/OPT/src/cl_OPT_Problem.hpp
@@ -41,7 +41,7 @@ namespace moris::opt
         real mPrevConGradMax   = 0.0;                  // last HEALTHY max |constraint gradient entry|
         bool mHasPrevGradients = false;                 // whether previous gradients are valid
         real mGradExplosionRatio = 1.0e6;              // (legacy) norm ratio threshold, kept for diagnostics
-        real mGradClipFactor     = 20.0;               // clip entries above this x the median nonzero |gradient|
+        real mGradClipFactor     = 0.0;                // clip entries above this x the median nonzero |gradient|; <= 0 = off (set via "grad_clip_factor")
 
         std::string mRestartFile;                      // Restart file
 

--- a/projects/OPT/src/fn_OPT_create_algorithm.cpp
+++ b/projects/OPT/src/fn_OPT_create_algorithm.cpp
@@ -10,6 +10,7 @@
 
 #include "fn_OPT_create_algorithm.hpp"
 #include "cl_OPT_Algorithm_GCMMA.hpp"
+#include "cl_OPT_Algorithm_MMA.hpp"
 #include "cl_OPT_Algorithm_SQP.hpp"
 #include "cl_OPT_Algorithm_LBFGS.hpp"
 #include "cl_OPT_Algorithm_Sweep.hpp"
@@ -23,6 +24,10 @@ namespace moris::opt
         if ( tAlgorithmName == "gcmma" )
         {
             return std::make_shared< OptAlgGCMMA >( aAlgorithmParameterList );
+        }
+        else if ( tAlgorithmName == "mma" )
+        {
+            return std::make_shared< Algorithm_MMA >( aAlgorithmParameterList );
         }
         else if ( tAlgorithmName == "sqp" )
         {

--- a/projects/OPT/test/opt_test.cpp
+++ b/projects/OPT/test/opt_test.cpp
@@ -28,6 +28,57 @@ namespace moris::opt
 
         // ---------------------------------------------------------------------------------------------------------
 
+        // Native in-tree GCMMA port (cl_OPT_Algorithm_MMA). No TPL dependency, so not guarded by
+        // MORIS_HAVE_GCMMA. Validates the native solver reaches the Rosenbrock minimum like the TPL.
+        SECTION( "MMA native" )
+        {
+            // Set up default parameter lists
+            Parameter_List tProblemParameterList   = moris::prm::create_opt_problem_parameter_list();
+            Parameter_List tAlgorithmParameterList = moris::prm::create_mma_parameter_list();
+
+            tAlgorithmParameterList.set( "norm_drop", 2.5e-5 );
+            tAlgorithmParameterList.set( "asymp_adaptc", 1.1 );
+
+            // Create interface
+            std::shared_ptr< Criteria_Interface > tInterface = std::make_shared< Interface_User_Defined >(
+                    &initialize_rosenbrock,
+                    &get_criteria_rosenbrock,
+                    &get_dcriteria_dadv_rosenbrock );
+
+            // Create Problem
+            std::shared_ptr< Problem > tProblem = std::make_shared< Problem_User_Defined >(
+                    tProblemParameterList,
+                    tInterface,
+                    &get_constraint_types_rosenbrock,
+                    &compute_objectives_rosenbrock,
+                    &compute_constraints_rosenbrock,
+                    &compute_dobjective_dadv_rosenbrock,
+                    &compute_dobjective_dcriteria_rosenbrock,
+                    &compute_dconstraint_dadv_rosenbrock,
+                    &compute_dconstraint_dcriteria_rosenbrock );
+
+            // Create manager
+            Submodule_Parameter_Lists tAlgorithms( "Algorithms" );
+            tAlgorithms.add_parameter_list( tAlgorithmParameterList );
+            Manager tManager( tAlgorithms, tProblem );
+
+            // Solve optimization problem
+            tManager.perform();
+
+            // Check Solution
+            if ( par_rank() == 0 )
+            {
+                REQUIRE( std::abs( tManager.get_objectives()( 0 ) ) < 2E-7 );    // check value of objective
+                Vector< real > tADVs = tManager.get_advs();
+                for ( auto iADV : tADVs )
+                {
+                    REQUIRE( std::abs( iADV - 1.0 ) < 1E-4 );
+                }
+            }
+        }
+
+        // ---------------------------------------------------------------------------------------------------------
+
 #ifdef MORIS_HAVE_GCMMA
         SECTION( "GCMMA" )
         {

--- a/projects/OPT/test/opt_test.cpp
+++ b/projects/OPT/test/opt_test.cpp
@@ -23,6 +23,80 @@
 
 namespace moris::opt
 {
+    // ---------------------------------------------------------------------------------------------------------
+    // Bimodal test problem for the gradient-explosion clip: one exploding sensitivity (1e8),
+    // three healthy entries (~0.01), one exactly-zero (inactive) entry -- the structure of a
+    // level-set design gradient with a small-cut-cell explosion.
+
+    namespace bimodal
+    {
+        void initialize(
+                Vector< real >& aADVs,
+                Vector< real >& aLowerBounds,
+                Vector< real >& aUpperBounds )
+        {
+            if ( par_rank() == 0 )
+            {
+                aADVs        = { 0.5, 0.5, 0.5, 0.5, 0.5 };
+                aLowerBounds = { 0.0, 0.0, 0.0, 0.0, 0.0 };
+                aUpperBounds = { 1.0, 1.0, 1.0, 1.0, 1.0 };
+            }
+        }
+
+        Vector< real > get_criteria( const Vector< real >& aADVs )
+        {
+            if ( par_rank() == 0 )
+            {
+                return { 1.0 };
+            }
+            return { {} };
+        }
+
+        Matrix< DDRMat > get_dcriteria_dadv( const Vector< real >& aADVs )
+        {
+            if ( par_rank() == 0 )
+            {
+                return { { 1.0e8, 0.01, 0.012, 0.008, 0.0 } };
+            }
+            return { {} };
+        }
+
+        Matrix< DDSMat > get_constraint_types()
+        {
+            return { { 1 } };
+        }
+
+        Matrix< DDRMat > compute_objectives( const Vector< real >& aADVs, const Vector< real >& aCriteria )
+        {
+            return { { aCriteria( 0 ) } };
+        }
+
+        Matrix< DDRMat > compute_constraints( const Vector< real >& aADVs, const Vector< real >& aCriteria )
+        {
+            return { { 0.0 } };
+        }
+
+        Matrix< DDRMat > compute_dobjective_dadv( const Vector< real >& aADVs, const Vector< real >& aCriteria )
+        {
+            return Matrix< DDRMat >( 1, 5, 0.0 );
+        }
+
+        Matrix< DDRMat > compute_dobjective_dcriteria( const Vector< real >& aADVs, const Vector< real >& aCriteria )
+        {
+            return { { 1.0 } };
+        }
+
+        Matrix< DDRMat > compute_dconstraint_dadv( const Vector< real >& aADVs, const Vector< real >& aCriteria )
+        {
+            return Matrix< DDRMat >( 1, 5, 0.0 );
+        }
+
+        Matrix< DDRMat > compute_dconstraint_dcriteria( const Vector< real >& aADVs, const Vector< real >& aCriteria )
+        {
+            return { { 0.0 } };
+        }
+    }    // namespace bimodal
+
     TEST_CASE( "[optimization]" )
     {
 
@@ -73,6 +147,68 @@ namespace moris::opt
                 for ( auto iADV : tADVs )
                 {
                     REQUIRE( std::abs( iADV - 1.0 ) < 1E-4 );
+                }
+            }
+        }
+
+        // ---------------------------------------------------------------------------------------------------------
+
+        // Gradient clip gate: off by default (raw gradient passes through untouched), and when
+        // enabled via "grad_clip_factor" the exploding entry is capped at factor x the median of
+        // the nonzero |entries| while healthy and zero entries are left alone.
+        SECTION( "Gradient clip gate" )
+        {
+            for ( bool tClipOn : { false, true } )
+            {
+                Parameter_List tProblemParameterList = moris::prm::create_opt_problem_parameter_list();
+
+                if ( tClipOn )
+                {
+                    tProblemParameterList.set( "grad_clip_factor", 20.0 );
+                }
+
+                std::shared_ptr< Criteria_Interface > tInterface = std::make_shared< Interface_User_Defined >(
+                        &bimodal::initialize,
+                        &bimodal::get_criteria,
+                        &bimodal::get_dcriteria_dadv );
+
+                std::shared_ptr< Problem > tProblem = std::make_shared< Problem_User_Defined >(
+                        tProblemParameterList,
+                        tInterface,
+                        &bimodal::get_constraint_types,
+                        &bimodal::compute_objectives,
+                        &bimodal::compute_constraints,
+                        &bimodal::compute_dobjective_dadv,
+                        &bimodal::compute_dobjective_dcriteria,
+                        &bimodal::compute_dconstraint_dadv,
+                        &bimodal::compute_dconstraint_dcriteria );
+
+                tProblem->initialize();
+
+                Vector< real > tADVs = tProblem->get_advs();
+                tProblem->compute_design_criteria( tADVs );
+                tProblem->compute_design_criteria_gradients( tADVs );
+
+                if ( par_rank() == 0 )
+                {
+                    const Matrix< DDRMat >& tObjGrad = tProblem->get_objective_gradients();
+
+                    if ( tClipOn )
+                    {
+                        // median of nonzero |entries| {1e8, 0.01, 0.012, 0.008} is 0.012 -> clip at 20 x 0.012
+                        REQUIRE( tObjGrad( 0, 0 ) == Approx( 20.0 * 0.012 ) );
+                    }
+                    else
+                    {
+                        // clip disabled: exploding entry passes through untouched
+                        REQUIRE( tObjGrad( 0, 0 ) == Approx( 1.0e8 ) );
+                    }
+
+                    // healthy and inactive entries are never modified
+                    REQUIRE( tObjGrad( 0, 1 ) == Approx( 0.01 ) );
+                    REQUIRE( tObjGrad( 0, 2 ) == Approx( 0.012 ) );
+                    REQUIRE( tObjGrad( 0, 3 ) == Approx( 0.008 ) );
+                    REQUIRE( tObjGrad( 0, 4 ) == 0.0 );
                 }
             }
         }

--- a/projects/PRM/src/fn_PRM_MORIS_GENERAL_Parameters.hpp
+++ b/projects/PRM/src/fn_PRM_MORIS_GENERAL_Parameters.hpp
@@ -80,6 +80,15 @@ namespace moris::prm
         aParameterlist.insert( "reinitialization_frequency", 1 );
         aParameterlist.insert( "output_mesh_file", "" );
         aParameterlist.insert( "time_offset", 0.0 );
+
+        // SDF reinitialization mode: "field_remap" (default) or "interface"
+        // "field_remap": Original mode - map solution field to target mesh
+        // "interface": Compute exact SDF from XTK interface facets
+        aParameterlist.insert( "sdf_reinit_mode", "field_remap" );
+
+        // Material phase index for sign determination in interface mode
+        // Nodes in this phase get negative SDF (inside), others get positive (outside)
+        aParameterlist.insert( "sdf_reinit_material_phase", 0 );
     }
 
     //------------------------------------------------------------------------------

--- a/projects/PRM/src/fn_PRM_OPT_Parameters.hpp
+++ b/projects/PRM/src/fn_PRM_OPT_Parameters.hpp
@@ -44,6 +44,15 @@ namespace moris::prm
         tParameterList.insert( "reinitialize_interface_iter", INT_MAX );          // number of iterations until the interface will be reinitialized
         tParameterList.insert( "first_reinitialize_interface_iter", INT_MAX );    // number of iterations until the interface will be reinitialized
 
+        // SDF reinitialization mode: "field_remap" (default) or "interface"
+        // "field_remap": Original mode - map solution field to target mesh
+        // "interface": Compute exact SDF from XTK interface facets
+        tParameterList.insert( "sdf_reinit_mode", "field_remap" );
+
+        // Material phase index for sign determination in interface mode
+        // Nodes in this phase get negative SDF (inside), others get positive (outside)
+        tParameterList.insert( "sdf_reinit_material_phase", 0 );
+
         return tParameterList;
     }
 

--- a/projects/PRM/src/fn_PRM_OPT_Parameters.hpp
+++ b/projects/PRM/src/fn_PRM_OPT_Parameters.hpp
@@ -17,6 +17,7 @@ namespace moris::opt
     enum class Optimization_Algorithm_Type
     {
         GCMMA,
+        MMA,
         LBFGS,
         SQP,
         SWEEP
@@ -52,6 +53,38 @@ namespace moris::prm
         // Material phase index for sign determination in interface mode
         // Nodes in this phase get negative SDF (inside), others get positive (outside)
         tParameterList.insert( "sdf_reinit_material_phase", 0 );
+
+        // Phases to exclude from interface facets (comma-separated, e.g., "0" or "0,2")
+        // Use this to exclude external material zones from SDF interface
+        tParameterList.insert( "sdf_exclude_phases", "" );
+
+        // Initialize the design as a signed distance field on the first optimization
+        // iteration (a one-time reinit at iter 1), so the optimizer starts from a true
+        // SDF (|grad phi| = 1) rather than a raw, possibly-clipped level-set field.
+        tParameterList.insert( "sdf_initialize_at_start", false );
+
+        // Wean off the SDF reinitialization once the design has converged. When the relative
+        // design-variable change between successive reinits, ||x_k - x_{k-1}||/||x_{k-1}||,
+        // drops below this tolerance, the optimizer has settled and further reinits only perturb
+        // the converged design -- so reinitialization is disabled for the rest of the run.
+        // 0 = disabled (always reinitialize on schedule).
+        tParameterList.insert( "sdf_reinit_wean_tol", 0.0 );
+
+        // Number of Laplacian smoothing iterations to apply after SDF reinitialization
+        // 0 = disabled (default), 2-5 for aggressive smoothing to remove thin features
+        tParameterList.insert( "sdf_smoothing_iterations", 0 );
+
+        // Laplacian smoothing strength (lambda) per iteration
+        // 0.0-1.0, smaller = lighter smoothing. Default 0.5
+        tParameterList.insert( "sdf_smoothing_lambda", 0.5 );
+
+        // Redistance the level set to a true SDF every iteration, applied in-place without a GCMMA
+        // restart (each per-step correction is tiny, so the optimizer's asymptotes stay valid).
+        // This keeps the field pinned near |grad phi|=1 at all times instead of letting it drift
+        // and collapse between scheduled reinits. When enabled, smoothing is decoupled and applied
+        // only every reinitialization_frequency iterations (on a clean SDF rather than a drifted one).
+        // false (default) = original behavior: redistance + smooth + NaN/restart on the schedule.
+        tParameterList.insert( "sdf_reinit_every_step", false );
 
         return tParameterList;
     }
@@ -101,6 +134,31 @@ namespace moris::prm
         tParameterList.insert( "step_size", 0.01 );       // GCMMA step size
         tParameterList.insert( "penalty", 100.0 );        // GCMMA constraint penalty
         tParameterList.insert( "version", 1 );            // GCMMA version
+
+        return tParameterList;
+    }
+
+    //--------------------------------------------------------------------------------------------------------------
+
+    inline Parameter_List
+    create_mma_parameter_list()
+    {
+        // Native in-tree GCMMA (cl_OPT_Algorithm_MMA). Same parameters as the TPL-backed "gcmma"
+        // algorithm; only "algorithm" differs so the factory dispatches to the native solver.
+        Parameter_List tParameterList( "MMA" );
+
+        tParameterList.insert( "algorithm", "mma" );      // Algorithm name, don't change
+        tParameterList.insert( "restart_index", 0 );      // Restart iteration index
+        tParameterList.insert( "max_its", 100 );          // Maximum number of iterations
+        tParameterList.insert( "max_inner_its", 0 );      // Maximum inner conservative cycles
+        tParameterList.insert( "norm_drop", 1e-4 );       // KKT relative-residual accuracy
+        tParameterList.insert( "asymp_adapt0", 0.5 );     // Initial asymptote adaptation factor
+        tParameterList.insert( "asymp_adaptb", 0.7 );     // Shrinking asymptote adaptation factor
+        tParameterList.insert( "asymp_adaptc", 1.2 );     // Expanding asymptote adaptation factor
+        tParameterList.insert( "step_size", 0.01 );       // Move-limit step size
+        tParameterList.insert( "penalty", 100.0 );        // Constraint penalty
+        tParameterList.insert( "version", 1 );            // Reserved (2002 solve only)
+        tParameterList.insert( "reinit_in_place", false );// In-place SDF redistance hook each iteration
 
         return tParameterList;
     }
@@ -249,6 +307,8 @@ namespace moris::prm
         {
             case opt::Optimization_Algorithm_Type::GCMMA:
                 return create_gcmma_parameter_list();
+            case opt::Optimization_Algorithm_Type::MMA:
+                return create_mma_parameter_list();
             case opt::Optimization_Algorithm_Type::LBFGS:
                 return create_lbfgs_parameter_list();
             case opt::Optimization_Algorithm_Type::SQP:

--- a/projects/PRM/src/fn_PRM_OPT_Parameters.hpp
+++ b/projects/PRM/src/fn_PRM_OPT_Parameters.hpp
@@ -42,6 +42,13 @@ namespace moris::prm
         tParameterList.insert( "finite_difference_epsilons", "1E-8" );    // Epsilon(s) to use per ADV for finite differencing
         tParameterList.insert( "library", "" );                           // Path to a shared object file for user-defined functions
 
+        // Consolidated end-of-run performance report (per-module wall time + memory).
+        // Granularity level: 0 = run total only, 1 = top-level modules, 2 = modules +
+        // nested sub-regions, 3 = full nested tracer tree. < 0 disables the report.
+        // Overridable at run time by the MORIS_PERF_LEVEL env var or the --perf-level CLI flag.
+        tParameterList.insert( "performance_report_level", 1 );
+        tParameterList.insert( "performance_report_file", "perf_report.json" );    // JSON report path (rank 0)
+
         tParameterList.insert( "reinitialize_interface_iter", INT_MAX );          // number of iterations until the interface will be reinitialized
         tParameterList.insert( "first_reinitialize_interface_iter", INT_MAX );    // number of iterations until the interface will be reinitialized
 

--- a/projects/PRM/src/fn_PRM_OPT_Parameters.hpp
+++ b/projects/PRM/src/fn_PRM_OPT_Parameters.hpp
@@ -86,6 +86,14 @@ namespace moris::prm
         // false (default) = original behavior: redistance + smooth + NaN/restart on the schedule.
         tParameterList.insert( "sdf_reinit_every_step", false );
 
+        // Gradient-explosion clip: cap each objective/constraint gradient entry at
+        // grad_clip_factor x the median of the nonzero |entries| (the active-sensitivity
+        // scale). Intended as a recovery tool for ill-conditioned designs where small XFEM
+        // cut cells make a few dIQI/dADV entries explode (~1/cell_volume). Note that it
+        // also caps legitimately large sensitivities, which can bias the descent direction.
+        // <= 0 (default) = disabled, the raw gradient is passed to the optimizer.
+        tParameterList.insert( "grad_clip_factor", 0.0 );
+
         return tParameterList;
     }
 

--- a/projects/SOL/DLA/src/cl_DLA_Eigen_Solver.cpp
+++ b/projects/SOL/DLA/src/cl_DLA_Eigen_Solver.cpp
@@ -741,13 +741,28 @@ int Eigen_Solver::solve_block_krylov_schur_system( Linear_Problem* aLinearSystem
         tverbosity += Anasazi::TimingDetails + Anasazi::IterationDetails + Anasazi::Debug + Anasazi::FinalSummary;
     }
 
+    // Derive a feasible Krylov subspace from the actual problem dimension N instead of relying
+    // on hardcoded parameters. Anasazi requires the maximum basis size (Num_Blocks*Block_Size)
+    // to be < N; too small a subspace fails to resolve clustered (e.g. smallest) eigenvalues.
+    // Use the user value as a lower hint, target a generous multiple of the block size, and
+    // clamp strictly below N so the solve neither overshoots (invalid_argument) nor starves.
+    const moris::sint tNumRows   = mMat->NumGlobalRows();
+    moris::sint       tBlockSize = std::max< moris::sint >( 1, mParameterList.get< moris::sint >( "Block_Size" ) );
+    tBlockSize                   = std::min< moris::sint >( tBlockSize, std::max< moris::sint >( 1, ( tNumRows - 1 ) / 2 ) );
+    // largest subspace that still leaves orthogonalization/restart headroom below N (going all
+    // the way to N-1 makes the SVQB orthogonalization infeasible on small problems).
+    const moris::sint tMaxFeasible = std::max< moris::sint >( 2 * tBlockSize, tNumRows - tBlockSize - 2 );
+    moris::sint       tTargetSubDim = std::max( mParameterList.get< moris::sint >( "MaxSubSpaceDims" ), (moris::sint)( 10 * tBlockSize ) );
+    moris::sint       tNumBlocks    = std::max< moris::sint >( 2, std::min( tTargetSubDim, tMaxFeasible ) / tBlockSize );
+    moris::sint       tMaxSubDim    = tNumBlocks * tBlockSize;
+
     // Set the parameters and pass to solver manager
     Teuchos::ParameterList MyPL;
     MyPL.set( "Verbosity", tverbosity );
     MyPL.set( "Which", mParameterList.get< std::string >( "Which" ) );
-    MyPL.set( "Block Size", mParameterList.get< moris::sint >( "Block_Size" ) );
-    MyPL.set( "Num Blocks", mParameterList.get< moris::sint >( "Num_Blocks" ) );
-    MyPL.set( "Maximum SubSpace Dimension", mParameterList.get< moris::sint >( "MaxSubSpaceDims" ) );
+    MyPL.set( "Block Size", tBlockSize );
+    MyPL.set( "Num Blocks", tNumBlocks );
+    MyPL.set( "Maximum SubSpace Dimension", tMaxSubDim );
     MyPL.set( "Maximum Restarts", mParameterList.get< moris::sint >( "MaxRestarts" ) );
     MyPL.set( "Convergence Tolerance", mParameterList.get< real >( "Convergence_Tolerance" ) );
     MyPL.set( "Relative Convergence Tolerance", mParameterList.get< bool >( "Relative_Convergence_Tolerance" ) );
@@ -755,14 +770,27 @@ int Eigen_Solver::solve_block_krylov_schur_system( Linear_Problem* aLinearSystem
     // Create the solver manager
     Anasazi::BlockKrylovSchurSolMgr< double, MV, OP > MySolverMan( mMyEigProblem, MyPL );
 
-    // Solve the problem
-    Anasazi::ReturnType tReturnCode = MySolverMan.solve();
-
-    // Check if the problem solve converged
-    if ( tReturnCode != Anasazi::Converged && MyPID == 0 )
+    // Solve the problem. The eigenvalue solve is an optional diagnostic: if it fails to converge
+    // OR throws internally (e.g. infeasible orthogonalization on small/clustered problems), warn
+    // and continue with the primary analysis rather than aborting the entire simulation.
+    Anasazi::ReturnType tReturnCode = Anasazi::Unconverged;
+    try
     {
-        MORIS_ERROR( false, "EigenSolver::SolveBlockKrylovSchurSystem: Solver returned UNconverged.\n" );
-        return -1;
+        tReturnCode = MySolverMan.solve();
+    }
+    catch ( const std::exception &aErr )
+    {
+        MORIS_LOG_WARNING( "EigenSolver::SolveBlockKrylovSchurSystem: eigen solve threw an exception (%s); "
+                           "skipping eigenvalue post-processing and continuing with the primary analysis.",
+                aErr.what() );
+        return 0;
+    }
+
+    if ( tReturnCode != Anasazi::Converged )
+    {
+        MORIS_LOG_WARNING( "EigenSolver::SolveBlockKrylovSchurSystem: solver returned UNconverged; "
+                           "skipping eigenvalue post-processing and continuing with the primary analysis." );
+        return 0;
     }
 
     // Get the eigenvalues and eigenvectors from the eigen problem

--- a/projects/WRK/src/cl_WRK_Reinitialize_Performer.cpp
+++ b/projects/WRK/src/cl_WRK_Reinitialize_Performer.cpp
@@ -44,6 +44,12 @@
 #include "cl_MSI_Equation_Model.hpp"
 #include "fn_sort.hpp"
 
+// XTK includes for interface-based SDF
+#include "cl_XTK_Cut_Integration_Mesh.hpp"
+
+// SDF includes for distance computation
+#include "cl_SDF_From_Interface.hpp"
+
 namespace moris::wrk
 {
     //------------------------------------------------------------------------------
@@ -260,4 +266,195 @@ namespace moris::wrk
         // Finalize
         tWriter.close_file( true );
     }
+
+    //------------------------------------------------------------------------------
+
+    void
+    Reinitialize_Performer::set_reinit_mode( ReinitMode aMode )
+    {
+        mReinitMode = aMode;
+    }
+
+    //------------------------------------------------------------------------------
+
+    ReinitMode
+    Reinitialize_Performer::get_reinit_mode() const
+    {
+        return mReinitMode;
+    }
+
+    //------------------------------------------------------------------------------
+
+    void
+    Reinitialize_Performer::set_material_phase( moris_index aPhase )
+    {
+        mMaterialPhase = aPhase;
+    }
+
+    //------------------------------------------------------------------------------
+
+    void
+    Reinitialize_Performer::compute_sdf_from_interface(
+            xtk::Cut_Integration_Mesh&                         aCutMesh,
+            mtk::Mesh*                                         aInterpMesh,
+            Vector< std::shared_ptr< gen::Geometry_Engine > >& aGENPerformer,
+            Vector< std::shared_ptr< mtk::Mesh_Manager > >&    aMTKPerformer,
+            std::shared_ptr< mtk::Field >&                     aSDFField )
+    {
+        Tracer tTracer( "WRK", "Reinitialize ADVs", "Compute SDF from Interface" );
+
+        // Get interface facets from XTK
+        Vector< moris_index > const& tInterfaceFacetIndices = aCutMesh.get_interface_facets();
+
+        if ( tInterfaceFacetIndices.size() == 0 )
+        {
+            MORIS_LOG_WARNING( "No interface facets found in XTK mesh, skipping SDF reinitialization" );
+            return;
+        }
+
+        // Get spatial dimension
+        uint tSpatialDim = aInterpMesh->get_spatial_dim();
+        uint tNodesPerFacet = ( tSpatialDim == 3 ) ? 3 : 2;  // Triangles in 3D, segments in 2D
+
+        // Count total facet nodes (may have duplicates, handled by connectivity)
+        uint tNumFacets = tInterfaceFacetIndices.size();
+
+        // Build facet connectivity and collect unique vertices
+        // For simplicity, we collect facet vertex coordinates directly
+        // Note: This is a simplified approach - production code may need
+        // to handle the facet-to-vertex mapping more carefully
+
+        // Get facet connectivity from XTK's facet-based connectivity
+        std::shared_ptr< xtk::Facet_Based_Connectivity > tFaceConn = aCutMesh.get_face_connectivity();
+
+        MORIS_ERROR( tFaceConn != nullptr,
+                "compute_sdf_from_interface - Face connectivity not available in XTK mesh" );
+
+        // Collect all unique facet node coordinates
+        std::map< moris_index, Matrix< DDRMat > > tUniqueVertexCoords;
+        Matrix< IndexMat > tFacetConn( tNumFacets, tNodesPerFacet );
+
+        for ( uint iFacet = 0; iFacet < tNumFacets; ++iFacet )
+        {
+            moris_index tFacetIndex = tInterfaceFacetIndices( iFacet );
+
+            // Get vertices of this facet directly from mFacetVertices member
+            Vector< moris::mtk::Vertex* > const& tFacetVertices = tFaceConn->mFacetVertices( tFacetIndex );
+
+            for ( uint iNode = 0; iNode < tNodesPerFacet && iNode < tFacetVertices.size(); ++iNode )
+            {
+                if ( tFacetVertices( iNode ) == nullptr )
+                {
+                    continue;  // Skip null vertices
+                }
+
+                moris_index tVertexIndex = tFacetVertices( iNode )->get_index();
+                tFacetConn( iFacet, iNode ) = tVertexIndex;
+
+                // Store vertex coordinates if not already present
+                if ( tUniqueVertexCoords.find( tVertexIndex ) == tUniqueVertexCoords.end() )
+                {
+                    tUniqueVertexCoords[ tVertexIndex ] = tFacetVertices( iNode )->get_coords();
+                }
+            }
+        }
+
+        // Build facet node coordinate matrix
+        uint tNumUniqueVerts = tUniqueVertexCoords.size();
+        Matrix< DDRMat > tFacetNodeCoords( tNumUniqueVerts, tSpatialDim );
+
+        // Create mapping from original indices to compact indices
+        std::map< moris_index, moris_index > tVertexIndexMap;
+        moris_index tCompactIdx = 0;
+        for ( auto const& [tOrigIdx, tCoords] : tUniqueVertexCoords )
+        {
+            tVertexIndexMap[ tOrigIdx ] = tCompactIdx;
+            for ( uint iDim = 0; iDim < tSpatialDim; ++iDim )
+            {
+                tFacetNodeCoords( tCompactIdx, iDim ) = tCoords( iDim );
+            }
+            ++tCompactIdx;
+        }
+
+        // Update facet connectivity to use compact indices
+        for ( uint iFacet = 0; iFacet < tNumFacets; ++iFacet )
+        {
+            for ( uint iNode = 0; iNode < tNodesPerFacet; ++iNode )
+            {
+                tFacetConn( iFacet, iNode ) = tVertexIndexMap[ tFacetConn( iFacet, iNode ) ];
+            }
+        }
+
+        // Get interpolation mesh node coordinates
+        uint tNumNodes = aInterpMesh->get_num_nodes();
+        Matrix< DDRMat > tNodeCoords( tNumNodes, tSpatialDim );
+
+        for ( uint iNode = 0; iNode < tNumNodes; ++iNode )
+        {
+            Matrix< DDRMat > tCoords = aInterpMesh->get_mtk_vertex( iNode ).get_coords();
+            for ( uint iDim = 0; iDim < tSpatialDim; ++iDim )
+            {
+                tNodeCoords( iNode, iDim ) = tCoords( iDim );
+            }
+        }
+
+        // Determine bulk phase per node using GEN
+        Vector< moris_index > tNodeBulkPhase( tNumNodes );
+        for ( uint iNode = 0; iNode < tNumNodes; ++iNode )
+        {
+            Matrix< DDRMat > tCoords = aInterpMesh->get_mtk_vertex( iNode ).get_coords();
+            tNodeBulkPhase( iNode ) = aGENPerformer( 0 )->get_phase_index( iNode, tCoords );
+        }
+
+        // Compute SDF using SDF_From_Interface
+        Matrix< DDRMat > tSDF;
+        sdf::SDF_From_Interface::compute(
+                tNumNodes,
+                tNodeCoords,
+                tFacetNodeCoords,
+                tFacetConn,
+                tNodeBulkPhase,
+                mMaterialPhase,
+                tSDF );
+
+        // Create MTK Field with computed SDF values
+        aSDFField = std::make_shared< mtk::Field_Discrete >(
+                aMTKPerformer( 0 )->get_mesh_pair( 0 ), mAdofMeshIndex );
+        aSDFField->set_label( mADVFiledName );
+        aSDFField->unlock_field();
+        aSDFField->set_values( tSDF );
+
+        // Map nodal values to coefficients
+        mtk::Mapper tMapper;
+        aSDFField->unlock_field();
+        tMapper.map_input_field_to_output_field_2( aSDFField.get() );
+
+        // Compute coefficients from nodal values
+        mCoefficients = aSDFField->get_coefficients();
+
+        // Clip values to bounds
+        this->impose_upper_lower_bound( aGENPerformer, aSDFField.get() );
+
+        // Store field for GEN update
+        Vector< std::shared_ptr< mtk::Field > > tGENFields;
+        tGENFields.append( aGENPerformer( 0 )->get_mtk_fields() );
+
+        // Find and replace the ADV field
+        auto itr = std::find_if( tGENFields.begin(), tGENFields.end(),
+                [ & ]( std::shared_ptr< mtk::Field > const& aField ) {
+                    return aField->get_label() == mADVFiledName;
+                } );
+
+        if ( itr != tGENFields.end() )
+        {
+            moris_index tADVFieldIndex = std::distance( tGENFields.begin(), itr );
+            tGENFields( tADVFieldIndex ) = aSDFField;
+        }
+
+        mMTKFields = tGENFields;
+
+        MORIS_LOG_INFO( "SDF reinitialization complete: %d nodes, %d interface facets",
+                tNumNodes, tNumFacets );
+    }
+
 }    // namespace moris::wrk

--- a/projects/WRK/src/cl_WRK_Reinitialize_Performer.cpp
+++ b/projects/WRK/src/cl_WRK_Reinitialize_Performer.cpp
@@ -81,6 +81,20 @@ namespace moris::wrk
         // get the mesh output info
         mOutputMeshFile = tMORISParameterList( 2 )( 0 ).get< std::string >( "output_mesh_file" );
         mTimeOffset     = tMORISParameterList( 2 )( 0 ).get< real >( "time_offset" );
+
+        // SDF reinitialization mode
+        std::string tReinitModeStr = tMORISParameterList( 2 )( 0 ).get< std::string >( "sdf_reinit_mode" );
+        if ( tReinitModeStr == "interface" )
+        {
+            mReinitMode = ReinitMode::INTERFACE_SDF;
+        }
+        else
+        {
+            mReinitMode = ReinitMode::FIELD_REMAP;  // Default
+        }
+
+        // Material phase for sign determination
+        mMaterialPhase = tMORISParameterList( 2 )( 0 ).get< sint >( "sdf_reinit_material_phase" );
     }
 
     //------------------------------------------------------------------------------

--- a/projects/WRK/src/cl_WRK_Reinitialize_Performer.cpp
+++ b/projects/WRK/src/cl_WRK_Reinitialize_Performer.cpp
@@ -11,6 +11,8 @@
 #include "cl_WRK_Reinitialize_Performer.hpp"
 
 #include <memory>
+#include <sstream>
+#include <set>
 #include "cl_Matrix.hpp"
 #include "cl_Tracer.hpp"
 #include "cl_Logger.hpp"
@@ -60,30 +62,10 @@ namespace moris::wrk
         // get the parameter lists
         Module_Parameter_Lists tMORISParameterList = aLibrary->get_parameters_for_module( Module_Type::MORISGENERAL );
         Module_Parameter_Lists tMSIParameterList   = aLibrary->get_parameters_for_module( Module_Type::MSI );
+        Module_Parameter_Lists tOPTParameterList   = aLibrary->get_parameters_for_module( Module_Type::OPT );
 
-        mAdofMeshIndex = tMSIParameterList( 0 )( 0 ).get< moris::sint >( tMORISParameterList( 2 )( 0 ).get< std::string >( "dof_type" ) );
-
-        // get the adv field name that wll be reinitialized
-        mADVFiledName = tMORISParameterList( 2 )( 0 ).get< std::string >( "adv_field" );
-
-        // get msi string to dof type map
-        moris::map< std::string, MSI::Dof_Type > tMSIDofTypeMap =
-                moris::MSI::get_msi_dof_type_map();
-
-        // get the quantity dof type from parameter list
-        string_to_vector(
-                tMORISParameterList( 2 )( 0 ).get< std::string >( "dof_type" ),
-                mDofTypes,
-                tMSIDofTypeMap );
-
-        mReinitializationFrequency = tMORISParameterList( 2 )( 0 ).get< sint >( "reinitialization_frequency" );
-
-        // get the mesh output info
-        mOutputMeshFile = tMORISParameterList( 2 )( 0 ).get< std::string >( "output_mesh_file" );
-        mTimeOffset     = tMORISParameterList( 2 )( 0 ).get< real >( "time_offset" );
-
-        // SDF reinitialization mode
-        std::string tReinitModeStr = tMORISParameterList( 2 )( 0 ).get< std::string >( "sdf_reinit_mode" );
+        // First determine the SDF reinit mode from OPT params
+        std::string tReinitModeStr = tOPTParameterList( 0 )( 0 ).get< std::string >( "sdf_reinit_mode" );
         if ( tReinitModeStr == "interface" )
         {
             mReinitMode = ReinitMode::INTERFACE_SDF;
@@ -93,8 +75,69 @@ namespace moris::wrk
             mReinitMode = ReinitMode::FIELD_REMAP;  // Default
         }
 
-        // Material phase for sign determination
-        mMaterialPhase = tMORISParameterList( 2 )( 0 ).get< sint >( "sdf_reinit_material_phase" );
+        // Material phase for sign determination - read from OPT params
+        mMaterialPhase = tOPTParameterList( 0 )( 0 ).get< sint >( "sdf_reinit_material_phase" );
+
+        // Phases to exclude from interface facets (e.g., external material zone)
+        std::string tExcludePhasesStr = tOPTParameterList( 0 )( 0 ).get< std::string >( "sdf_exclude_phases" );
+        if ( !tExcludePhasesStr.empty() )
+        {
+            // Parse comma-separated list of phase indices
+            std::stringstream ss( tExcludePhasesStr );
+            std::string token;
+            while ( std::getline( ss, token, ',' ) )
+            {
+                // Trim whitespace
+                token.erase( 0, token.find_first_not_of( " \t" ) );
+                token.erase( token.find_last_not_of( " \t" ) + 1 );
+                if ( !token.empty() )
+                {
+                    mExcludePhases.push_back( std::stoi( token ) );
+                }
+            }
+        }
+
+        // Number of Laplacian smoothing iterations
+        mSmoothingIterations = tOPTParameterList( 0 )( 0 ).get< sint >( "sdf_smoothing_iterations" );
+        
+        // Laplacian smoothing strength (lambda)
+        mSmoothingLambda = tOPTParameterList( 0 )( 0 ).get< real >( "sdf_smoothing_lambda" );
+
+        // Initialize the design as an SDF on the first optimization iteration
+        mInitializeAtStart = tOPTParameterList( 0 )( 0 ).get< bool >( "sdf_initialize_at_start" );
+
+        // Wean-off tolerance on the reinit's relative change to the field
+        mWeanTol = tOPTParameterList( 0 )( 0 ).get< real >( "sdf_reinit_wean_tol" );
+
+        // Redistance every iteration in-place (no GCMMA restart); smooth every reinit_freq
+        mReinitEveryStep = tOPTParameterList( 0 )( 0 ).get< bool >( "sdf_reinit_every_step" );
+
+        mADVFiledName = tMORISParameterList( 2 )( 0 ).get< std::string >( "adv_field" );
+        
+        // Reinitialization frequency from mapping params
+        mReinitializationFrequency = tMORISParameterList( 2 )( 0 ).get< sint >( "reinitialization_frequency" );
+
+        // get the mesh output info
+        mOutputMeshFile = tMORISParameterList( 2 )( 0 ).get< std::string >( "output_mesh_file" );
+        mTimeOffset     = tMORISParameterList( 2 )( 0 ).get< real >( "time_offset" );
+
+        // dof_type is only needed for FIELD_REMAP mode  
+        if ( mReinitMode == ReinitMode::FIELD_REMAP )
+        {
+            std::string tDofTypeStr = tMORISParameterList( 2 )( 0 ).get< std::string >( "dof_type" );
+            
+            if ( !tDofTypeStr.empty() )
+            {
+                mAdofMeshIndex = tMSIParameterList( 0 )( 0 ).get< moris::sint >( tDofTypeStr );
+
+                // get msi string to dof type map
+                moris::map< std::string, MSI::Dof_Type > tMSIDofTypeMap =
+                        moris::MSI::get_msi_dof_type_map();
+
+                // get the quantity dof type from parameter list
+                string_to_vector( tDofTypeStr, mDofTypes, tMSIDofTypeMap );
+            }
+        }
     }
 
     //------------------------------------------------------------------------------
@@ -299,10 +342,42 @@ namespace moris::wrk
 
     //------------------------------------------------------------------------------
 
+    bool
+    Reinitialize_Performer::get_initialize_at_start() const
+    {
+        return mInitializeAtStart;
+    }
+
+    //------------------------------------------------------------------------------
+
+    bool
+    Reinitialize_Performer::last_reinit_below_wean_tol() const
+    {
+        return mLastReinitBelowWeanTol;
+    }
+
+    //------------------------------------------------------------------------------
+
     void
     Reinitialize_Performer::set_material_phase( moris_index aPhase )
     {
         mMaterialPhase = aPhase;
+    }
+
+    //------------------------------------------------------------------------------
+
+    Vector< moris_index > const&
+    Reinitialize_Performer::get_exclude_phases() const
+    {
+        return mExcludePhases;
+    }
+
+    //------------------------------------------------------------------------------
+
+    void
+    Reinitialize_Performer::set_exclude_phases( Vector< moris_index > const& aExcludePhases )
+    {
+        mExcludePhases = aExcludePhases;
     }
 
     //------------------------------------------------------------------------------
@@ -313,36 +388,152 @@ namespace moris::wrk
             mtk::Mesh*                                         aInterpMesh,
             Vector< std::shared_ptr< gen::Geometry_Engine > >& aGENPerformer,
             Vector< std::shared_ptr< mtk::Mesh_Manager > >&    aMTKPerformer,
-            std::shared_ptr< mtk::Field >&                     aSDFField )
+            std::shared_ptr< mtk::Field >&                     aSDFField,
+            bool                                               aApplySmoothing )
     {
         Tracer tTracer( "WRK", "Reinitialize ADVs", "Compute SDF from Interface" );
-
-        // Get interface facets from XTK
-        Vector< moris_index > const& tInterfaceFacetIndices = aCutMesh.get_interface_facets();
-
-        if ( tInterfaceFacetIndices.size() == 0 )
-        {
-            MORIS_LOG_WARNING( "No interface facets found in XTK mesh, skipping SDF reinitialization" );
-            return;
-        }
 
         // Get spatial dimension
         uint tSpatialDim = aInterpMesh->get_spatial_dim();
         uint tNodesPerFacet = ( tSpatialDim == 3 ) ? 3 : 2;  // Triangles in 3D, segments in 2D
-
-        // Count total facet nodes (may have duplicates, handled by connectivity)
-        uint tNumFacets = tInterfaceFacetIndices.size();
-
-        // Build facet connectivity and collect unique vertices
-        // For simplicity, we collect facet vertex coordinates directly
-        // Note: This is a simplified approach - production code may need
-        // to handle the facet-to-vertex mapping more carefully
-
+        
         // Get facet connectivity from XTK's facet-based connectivity
         std::shared_ptr< xtk::Facet_Based_Connectivity > tFaceConn = aCutMesh.get_face_connectivity();
 
         MORIS_ERROR( tFaceConn != nullptr,
                 "compute_sdf_from_interface - Face connectivity not available in XTK mesh" );
+
+        // =========================================================================
+        // Phase-based facet filtering using bulk-phase-to-bulk-phase interface
+        // =========================================================================
+        
+        Vector< moris_index > tFilteredFacetIndices;
+        
+        if ( mExcludePhases.size() > 0 )
+        {
+            // Get bulk-phase-to-bulk-phase interface
+            auto const& tBpToBpInterface = aCutMesh.get_bulk_phase_to_bulk_phase_dbl_side_interface();
+            uint tNumPhases = tBpToBpInterface.size();
+            
+            // Helper to check if a phase is excluded
+            auto tIsExcluded = [this]( moris_index aPhase ) {
+                for ( uint i = 0; i < mExcludePhases.size(); ++i )
+                {
+                    if ( mExcludePhases( i ) == aPhase )
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            };
+            
+            // Iterate through all phase pairs and collect facets from allowed pairs
+            uint tTotalFacets = 0;
+            uint tExcludedFacets = 0;
+            
+            for ( uint iP0 = 0; iP0 < tNumPhases; ++iP0 )
+            {
+                for ( uint iP1 = 0; iP1 < tBpToBpInterface( iP0 ).size(); ++iP1 )
+                {
+                    // Skip if no interface between these phases
+                    if ( tBpToBpInterface( iP0 )( iP1 ) == nullptr )
+                    {
+                        continue;
+                    }
+                    
+                    // Check if either phase is excluded
+                    bool tExcludeThisPair = tIsExcluded( iP0 ) || tIsExcluded( iP1 );
+                    
+                    // Get the double-side group for this phase pair
+                    std::shared_ptr< xtk::IG_Cell_Double_Side_Group > tDblSideGroup = tBpToBpInterface( iP0 )( iP1 );
+                    uint tNumFacetsInPair = tDblSideGroup->mLeaderIgCells.size();
+                    
+                    if ( tExcludeThisPair )
+                    {
+                        tExcludedFacets += tNumFacetsInPair;
+                    }
+                    else
+                    {
+                        // This phase pair is allowed - we don't have direct facet indices here,
+                        // so we'll need to use the global interface facets but filter somehow
+                        // For now, track that we need these facets
+                        tTotalFacets += tNumFacetsInPair;
+                    }
+                }
+            }
+            
+            MORIS_LOG_INFO( "Phase exclusion: keeping %d facets from %d phases, excluded %d facets from phase pairs containing excluded phases",
+                    tTotalFacets, tNumPhases, tExcludedFacets );
+            
+            // Since the bulk-phase interface doesn't give us direct facet indices,
+            // we need to filter the global interface facets based on which phases they connect.
+            // We can determine this by checking the bulk phase of cells adjacent to each facet.
+            
+            Vector< moris_index > const& tAllInterfaceFacetIndices = aCutMesh.get_interface_facets();
+            
+            // For each facet, check the bulk phases of adjacent cells
+            for ( uint iFacet = 0; iFacet < tAllInterfaceFacetIndices.size(); ++iFacet )
+            {
+                moris_index tFacetIndex = tAllInterfaceFacetIndices( iFacet );
+                
+                // Skip if facet index is invalid
+                if ( tFacetIndex < 0 || (uint)tFacetIndex >= tFaceConn->mFacetToCell.size() )
+                {
+                    continue;
+                }
+                
+                // Get cells adjacent to this facet
+                Vector< moris::mtk::Cell* > const& tAdjacentCells = tFaceConn->mFacetToCell( tFacetIndex );
+                
+                // Count valid (non-null) adjacent cells and check bulk phases
+                uint tValidCellCount = 0;
+                bool tFacetHasExcludedPhase = false;
+                
+                for ( uint iCell = 0; iCell < tAdjacentCells.size(); ++iCell )
+                {
+                    if ( tAdjacentCells( iCell ) != nullptr )
+                    {
+                        ++tValidCellCount;
+                        moris_index tCellIndex = tAdjacentCells( iCell )->get_index();
+                        moris_index tBulkPhase = aCutMesh.get_cell_bulk_phase( tCellIndex );
+                        if ( tIsExcluded( tBulkPhase ) )
+                        {
+                            tFacetHasExcludedPhase = true;
+                        }
+                    }
+                }
+                
+                // Exclude facet if:
+                // 1. It has less than 2 valid adjacent cells (domain boundary facet), OR
+                // 2. Any adjacent cell is in an excluded phase
+                if ( tValidCellCount < 2 || tFacetHasExcludedPhase )
+                {
+                    continue;
+                }
+                
+                tFilteredFacetIndices.push_back( tFacetIndex );
+            }
+            
+            MORIS_LOG_INFO( "Phase filtering: %zu facets after filtering (from %zu total)",
+                    tFilteredFacetIndices.size(), tAllInterfaceFacetIndices.size() );
+        }
+        else
+        {
+            // No phase exclusion - use all interface facets
+            Vector< moris_index > const& tAllInterfaceFacetIndices = aCutMesh.get_interface_facets();
+            tFilteredFacetIndices = tAllInterfaceFacetIndices;
+        }
+
+        Vector< moris_index > const& tInterfaceFacetIndices = tFilteredFacetIndices;
+
+        if ( tInterfaceFacetIndices.size() == 0 )
+        {
+            MORIS_LOG_WARNING( "No interface facets found after filtering, skipping SDF reinitialization" );
+            return;
+        }
+
+        // Count facets
+        uint tNumFacets = tInterfaceFacetIndices.size();
 
         // Collect all unique facet node coordinates
         std::map< moris_index, Matrix< DDRMat > > tUniqueVertexCoords;
@@ -351,6 +542,14 @@ namespace moris::wrk
         for ( uint iFacet = 0; iFacet < tNumFacets; ++iFacet )
         {
             moris_index tFacetIndex = tInterfaceFacetIndices( iFacet );
+
+            // Bounds check for facet index
+            if ( tFacetIndex < 0 || (uint)tFacetIndex >= tFaceConn->mFacetVertices.size() )
+            {
+                MORIS_LOG_WARNING( "Facet index %d out of bounds (max %zu), skipping",
+                        tFacetIndex, tFaceConn->mFacetVertices.size() );
+                continue;
+            }
 
             // Get vertices of this facet directly from mFacetVertices member
             Vector< moris::mtk::Vertex* > const& tFacetVertices = tFaceConn->mFacetVertices( tFacetIndex );
@@ -420,6 +619,25 @@ namespace moris::wrk
             tNodeBulkPhase( iNode ) = aGENPerformer( 0 )->get_phase_index( iNode, tCoords );
         }
 
+        // Grab the EXISTING level-set field's nodal values so we can preserve its sign.
+        // Re-deriving the sign from the bulk phase every reinit is inconsistent with GEN's
+        // level-set convention, so the GEN->SDF->GEN round-trip inverts the field at each
+        // reinit (period-2 limit cycle). Preserving the existing sign keeps the geometry fixed
+        // and makes the reinit a pure redistancing (correct |grad phi|, same inside/outside).
+        Matrix< DDRMat > tExistingValues;
+        {
+            Vector< std::shared_ptr< mtk::Field > > tCurrentFields;
+            tCurrentFields.append( aGENPerformer( 0 )->get_mtk_fields() );
+            auto tSrcItr = std::find_if( tCurrentFields.begin(), tCurrentFields.end(),
+                    [ & ]( std::shared_ptr< mtk::Field > const& aField ) {
+                        return aField->get_label() == mADVFiledName;
+                    } );
+            if ( tSrcItr != tCurrentFields.end() )
+            {
+                tExistingValues = ( *tSrcItr )->get_values();
+            }
+        }
+
         // Compute SDF using SDF_From_Interface
         Matrix< DDRMat > tSDF;
         sdf::SDF_From_Interface::compute(
@@ -431,12 +649,89 @@ namespace moris::wrk
                 mMaterialPhase,
                 tSDF );
 
+        // Preserve the sign of the existing field instead of the bulk-phase-derived sign.
+        // Falls back to the computed (bulk-phase) sign if the existing field is unavailable.
+        if ( tExistingValues.numel() == tSDF.numel() )
+        {
+            for ( uint iNode = 0; iNode < tSDF.numel(); ++iNode )
+            {
+                real tSign = ( tExistingValues( iNode ) >= 0.0 ) ? 1.0 : -1.0;
+                tSDF( iNode ) = tSign * std::abs( tSDF( iNode ) );
+            }
+        }
+
+        // Get ADV bounds to clamp the signed distance into the design-variable range
+        real tLowerBound = aGENPerformer( 0 )->get_lower_bounds()( 0 );
+        real tUpperBound = aGENPerformer( 0 )->get_upper_bounds()( 0 );
+
+        // Helper to check if a phase is excluded (for logging only; the facets of excluded
+        // phases were already filtered out of the interface above, so excluded-phase nodes
+        // already carry the true distance to the nearest *kept* facet)
+        uint tPhaseExcludedNodes = 0;
+        auto tIsExcludedPhase = [this]( moris_index aPhase ) {
+            for ( uint i = 0; i < mExcludePhases.size(); ++i )
+            {
+                if ( mExcludePhases( i ) == aPhase )
+                {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        // Clamp the true signed distance to the ADV bounds. Excluded-phase and domain-boundary
+        // nodes are NOT saturated to +/- the bound magnitude: they keep the genuine distance to
+        // the nearest (non-excluded) interface facet, so the field stays a true signed distance
+        // everywhere instead of forming an artificial +/-bound wall at the frame/boundary.
+        for ( uint iNode = 0; iNode < tNumNodes; ++iNode )
+        {
+            if ( mExcludePhases.size() > 0 && tIsExcludedPhase( tNodeBulkPhase( iNode ) ) )
+            {
+                ++tPhaseExcludedNodes;
+            }
+
+            tSDF( iNode ) = std::max( tLowerBound, std::min( tSDF( iNode ), tUpperBound ) );
+        }
+
+        MORIS_LOG_INFO( "SDF clamped to [%.4f, %.4f], phase-excluded nodes: %d (true distance kept, no boundary saturation)",
+                tLowerBound, tUpperBound, tPhaseExcludedNodes );
+
+        // Diagnostic only: the relative correction this reinit makes to the field, ||SDF(x)-x||/||x||.
+        // This is the field's between-reinit drift (dominated by |grad phi| re-normalization) and does
+        // NOT shrink at convergence, so it is logged for insight but no longer drives the wean-off
+        // decision. Weaning is decided in the workflow from the actual design-variable change.
+        mLastReinitBelowWeanTol = false;
+        if ( tExistingValues.numel() == tSDF.numel() )
+        {
+            real tNumer = 0.0;
+            real tDenom = 0.0;
+            for ( uint iNode = 0; iNode < tSDF.numel(); ++iNode )
+            {
+                tNumer += std::pow( tSDF( iNode ) - tExistingValues( iNode ), 2 );
+                tDenom += std::pow( tExistingValues( iNode ), 2 );
+            }
+            real tRelChange = ( tDenom > 0.0 ) ? std::sqrt( tNumer / tDenom ) : 0.0;
+            MORIS_LOG_INFO( "SDF reinit field drift (diagnostic): %.4e", tRelChange );
+        }
+
         // Create MTK Field with computed SDF values
+        // For INTERFACE_SDF mode, use mesh index 0 (since mAdofMeshIndex isn't set)
+        moris_index tMeshIndex = ( mReinitMode == ReinitMode::INTERFACE_SDF ) ? 0 : mAdofMeshIndex;
+        
         aSDFField = std::make_shared< mtk::Field_Discrete >(
-                aMTKPerformer( 0 )->get_mesh_pair( 0 ), mAdofMeshIndex );
+                aMTKPerformer( 0 )->get_mesh_pair( 0 ), tMeshIndex );
         aSDFField->set_label( mADVFiledName );
         aSDFField->unlock_field();
         aSDFField->set_values( tSDF );
+
+        // Apply Laplacian smoothing if enabled (and requested this call). In every-step mode
+        // smoothing is decoupled from redistancing and only requested every reinit_freq iterations.
+        if ( mSmoothingIterations > 0 && aApplySmoothing )
+        {
+            apply_laplacian_smoothing( tSDF, aInterpMesh, mSmoothingIterations, mSmoothingLambda );
+            aSDFField->unlock_field();
+            aSDFField->set_values( tSDF );
+        }
 
         // Map nodal values to coefficients
         mtk::Mapper tMapper;
@@ -469,6 +764,74 @@ namespace moris::wrk
 
         MORIS_LOG_INFO( "SDF reinitialization complete: %d nodes, %d interface facets",
                 tNumNodes, tNumFacets );
+    }
+
+    //------------------------------------------------------------------------------
+
+    void
+    Reinitialize_Performer::apply_laplacian_smoothing(
+            Matrix< DDRMat >&   aCoefficients,
+            mtk::Mesh*          aInterpMesh,
+            uint                aNumIterations,
+            real                aLambda )
+    {
+        // Get number of nodes
+        uint tNumNodes = aCoefficients.numel();
+
+        MORIS_LOG_INFO( "Applying Laplacian smoothing: %d nodes, %d iterations, lambda=%.2f",
+                tNumNodes, aNumIterations, aLambda );
+
+        // For each smoothing iteration
+        for ( uint iIter = 0; iIter < aNumIterations; ++iIter )
+        {
+            // Create copy of current values
+            Matrix< DDRMat > tOldValues = aCoefficients;
+
+            // For each node, compute weighted average with neighbors
+            for ( uint iNode = 0; iNode < tNumNodes; ++iNode )
+            {
+                // Get elements connected to this node
+                Matrix< IndexMat > tConnectedElements = aInterpMesh->get_elements_connected_to_node_loc_inds( iNode );
+
+                // Collect unique neighbor nodes
+                std::set< moris_index > tNeighborNodes;
+
+                for ( uint iElem = 0; iElem < tConnectedElements.numel(); ++iElem )
+                {
+                    moris_index tElemIndex = tConnectedElements( iElem );
+
+                    // Get nodes of this element
+                    Matrix< IndexMat > tElemNodes = aInterpMesh->get_nodes_connected_to_element_loc_inds( tElemIndex );
+
+                    for ( uint iElemNode = 0; iElemNode < tElemNodes.numel(); ++iElemNode )
+                    {
+                        moris_index tNeighborNode = tElemNodes( iElemNode );
+                        if ( tNeighborNode != (moris_index)iNode && tNeighborNode < (moris_index)tNumNodes )
+                        {
+                            tNeighborNodes.insert( tNeighborNode );
+                        }
+                    }
+                }
+
+                // Compute average of neighbor values
+                if ( !tNeighborNodes.empty() )
+                {
+                    real tNeighborSum = 0.0;
+                    for ( moris_index tNeighbor : tNeighborNodes )
+                    {
+                        tNeighborSum += tOldValues( tNeighbor );
+                    }
+                    real tNeighborAvg = tNeighborSum / tNeighborNodes.size();
+
+                    // Apply Laplacian smoothing: new = (1-lambda)*old + lambda*neighbor_avg
+                    aCoefficients( iNode ) = ( 1.0 - aLambda ) * tOldValues( iNode ) + aLambda * tNeighborAvg;
+                }
+                // If no neighbors (shouldn't happen), keep original value
+            }
+        }
+
+        MORIS_LOG_INFO( "Laplacian smoothing complete. ADV range: [%.6f, %.6f]",
+                aCoefficients.min(), aCoefficients.max() );
     }
 
 }    // namespace moris::wrk

--- a/projects/WRK/src/cl_WRK_Reinitialize_Performer.hpp
+++ b/projects/WRK/src/cl_WRK_Reinitialize_Performer.hpp
@@ -46,8 +46,22 @@ namespace moris
         class Model;
     }
 
+    namespace xtk
+    {
+        class Cut_Integration_Mesh;
+    }
+
     namespace wrk
     {
+        /**
+         * @brief Mode for SDF reinitialization
+         */
+        enum class ReinitMode
+        {
+            FIELD_REMAP,     ///< Original: remap solution field to target mesh
+            INTERFACE_SDF    ///< New: compute exact SDF from XTK interface facets
+        };
+
         class Reinitialize_Performer
         {
           private:
@@ -74,6 +88,10 @@ namespace moris
             // mesh outputting params
             std::string mOutputMeshFile;
             moris::real mTimeOffset;
+
+            // SDF reinitialization mode and parameters
+            ReinitMode  mReinitMode     = ReinitMode::FIELD_REMAP;
+            moris_index mMaterialPhase  = 0;    ///< Bulk phase index for "inside" (negative SDF)
 
           public:
             //------------------------------------------------------------------------------
@@ -166,6 +184,57 @@ namespace moris
              */
             void
             output_fields( mtk::Field* aTarget, mtk::Field* aSource, std::string aExoFileName ) const;
+
+            //------------------------------------------------------------------------------
+
+            /**
+             * @brief Set the reinitialization mode
+             *
+             * @param aMode FIELD_REMAP (original) or INTERFACE_SDF (new)
+             */
+            void
+            set_reinit_mode( ReinitMode aMode );
+
+            //------------------------------------------------------------------------------
+
+            /**
+             * @brief Get the current reinitialization mode
+             */
+            ReinitMode
+            get_reinit_mode() const;
+
+            //------------------------------------------------------------------------------
+
+            /**
+             * @brief Set the material phase index (for sign determination)
+             *
+             * @param aPhase Bulk phase index that represents "inside" (negative SDF)
+             */
+            void
+            set_material_phase( moris_index aPhase );
+
+            //------------------------------------------------------------------------------
+
+            /**
+             * @brief Compute SDF from XTK interface facets
+             *
+             * Uses the triangulated interface from XTK to compute exact signed
+             * distances at all mesh nodes. This is an alternative to field remapping
+             * that maintains the exact SDF property (|∇φ| = 1).
+             *
+             * @param aCutMesh XTK cut integration mesh containing interface facets
+             * @param aInterpMesh Interpolation mesh (Lagrange nodes)
+             * @param aGENPerformer Geometry engine for ADV updates
+             * @param aMTKPerformer Mesh manager
+             * @param aSDFField Output: MTK field with reinitialized SDF values
+             */
+            void
+            compute_sdf_from_interface(
+                    xtk::Cut_Integration_Mesh&                       aCutMesh,
+                    mtk::Mesh*                                       aInterpMesh,
+                    Vector< std::shared_ptr< gen::Geometry_Engine > >& aGENPerformer,
+                    Vector< std::shared_ptr< mtk::Mesh_Manager > >&  aMTKPerformer,
+                    std::shared_ptr< mtk::Field >&                   aSDFField );
         };
     }    // namespace wrk
 }    // namespace moris

--- a/projects/WRK/src/cl_WRK_Reinitialize_Performer.hpp
+++ b/projects/WRK/src/cl_WRK_Reinitialize_Performer.hpp
@@ -92,6 +92,13 @@ namespace moris
             // SDF reinitialization mode and parameters
             ReinitMode  mReinitMode     = ReinitMode::FIELD_REMAP;
             moris_index mMaterialPhase  = 0;    ///< Bulk phase index for "inside" (negative SDF)
+            Vector< moris_index > mExcludePhases;  ///< Bulk phases to exclude from interface (e.g., external zone)
+            uint mSmoothingIterations = 0;  ///< Number of Laplacian smoothing iterations (0 = disabled)
+            real mSmoothingLambda = 0.5;  ///< Laplacian smoothing strength (0.0-1.0)
+            bool mInitializeAtStart = false;  ///< Reinit once at the first iteration to start from a true SDF
+            real mWeanTol = 0.0;              ///< Wean-off tolerance on the reinit's relative change (0 = disabled)
+            bool mLastReinitBelowWeanTol = false;  ///< Set when the most recent reinit's change fell below mWeanTol
+            bool mReinitEveryStep = false;    ///< Redistance every iteration in-place (no restart); smooth every reinit_freq
 
           public:
             //------------------------------------------------------------------------------
@@ -206,12 +213,87 @@ namespace moris
             //------------------------------------------------------------------------------
 
             /**
+             * @brief Whether to initialize the design as an SDF on the first iteration
+             *
+             * @return true if a one-time reinit should fire at the first optimization iteration
+             */
+            bool
+            get_initialize_at_start() const;
+
+            //------------------------------------------------------------------------------
+
+            /**
+             * @brief Whether the most recent reinit's relative change fell below the wean tolerance
+             *
+             * @return true if the reinit has stopped doing meaningful work and should be weaned off
+             */
+            bool
+            last_reinit_below_wean_tol() const;
+
+            //------------------------------------------------------------------------------
+
+            /**
+             * @brief Wean-off tolerance on the relative design-variable change (0 = disabled)
+             *
+             * @return the configured sdf_reinit_wean_tol
+             */
+            real
+            get_wean_tol() const { return mWeanTol; }
+
+            //------------------------------------------------------------------------------
+
+            /**
+             * @brief Whether to redistance the SDF every iteration in-place (no GCMMA restart)
+             *
+             * @return true if every-step redistancing is enabled
+             */
+            bool
+            get_reinit_every_step() const { return mReinitEveryStep; }
+
+            //------------------------------------------------------------------------------
+
+            /**
              * @brief Set the material phase index (for sign determination)
              *
              * @param aPhase Bulk phase index that represents "inside" (negative SDF)
              */
             void
             set_material_phase( moris_index aPhase );
+
+            //------------------------------------------------------------------------------
+
+            /**
+             * @brief Get the excluded phases for SDF interface computation
+             *
+             * @return Vector of bulk phase indices to exclude from interface facets
+             */
+            Vector< moris_index > const&
+            get_exclude_phases() const;
+
+            //------------------------------------------------------------------------------
+
+            /**
+             * @brief Set phases to exclude from SDF interface computation
+             *
+             * @param aExcludePhases Vector of bulk phase indices to exclude
+             */
+            void
+            set_exclude_phases( Vector< moris_index > const& aExcludePhases );
+
+            //------------------------------------------------------------------------------
+
+            /**
+             * @brief Get number of Laplacian smoothing iterations for SDF reinit
+             */
+            uint
+            get_smoothing_iterations() const { return mSmoothingIterations; }
+
+            /**
+             * @brief Set number of Laplacian smoothing iterations for SDF reinit
+             * @param aNumIter Number of iterations (0 = disabled, 1-5 recommended)
+             */
+            void
+            set_smoothing_iterations( uint aNumIter ) { mSmoothingIterations = aNumIter; }
 
             //------------------------------------------------------------------------------
 
@@ -227,6 +309,8 @@ namespace moris
              * @param aGENPerformer Geometry engine for ADV updates
              * @param aMTKPerformer Mesh manager
              * @param aSDFField Output: MTK field with reinitialized SDF values
+             * @param aApplySmoothing Whether to apply Laplacian smoothing this call (decoupled from
+             *        redistancing in every-step mode, where smoothing runs only every reinit_freq)
              */
             void
             compute_sdf_from_interface(
@@ -234,7 +318,29 @@ namespace moris
                     mtk::Mesh*                                       aInterpMesh,
                     Vector< std::shared_ptr< gen::Geometry_Engine > >& aGENPerformer,
                     Vector< std::shared_ptr< mtk::Mesh_Manager > >&  aMTKPerformer,
-                    std::shared_ptr< mtk::Field >&                   aSDFField );
+                    std::shared_ptr< mtk::Field >&                   aSDFField,
+                    bool                                             aApplySmoothing = true );
+
+            //------------------------------------------------------------------------------
+
+            /**
+             * @brief Apply Laplacian smoothing to the ADV field
+             *
+             * This method smooths the ADV field by averaging each node's value
+             * with its neighbors. Used for failure recovery to remove thin features
+             * and small islands that cause numerical instabilities.
+             *
+             * @param aCoefficients ADV values to smooth (modified in place)
+             * @param aInterpMesh   Interpolation mesh (for connectivity)
+             * @param aNumIterations Number of smoothing iterations (default: 3)
+             * @param aLambda       Smoothing factor in [0,1], higher = more smoothing (default: 0.5)
+             */
+            static void
+            apply_laplacian_smoothing(
+                    Matrix< DDRMat >&   aCoefficients,
+                    mtk::Mesh*          aInterpMesh,
+                    uint                aNumIterations = 3,
+                    real                aLambda = 0.5 );
         };
     }    // namespace wrk
 }    // namespace moris

--- a/projects/WRK/src/cl_WRK_Workflow_HMR_XTK.cpp
+++ b/projects/WRK/src/cl_WRK_Workflow_HMR_XTK.cpp
@@ -113,6 +113,53 @@ namespace moris::wrk
         Tracer tTracer( "WRK", "HMR-XTK Workflow", "Initialize" );
 
         mInitializeOptimizationRestart = false;
+        
+        // If mSDFReinitPending was true, we're coming from an SDF reinit restart.
+        // Set skip flag to prevent re-triggering SDF reinit on the restart pass.
+        // Also apply the computed SDF coefficients to GEN BEFORE distribute_advs().
+        if ( mSDFReinitPending )
+        {
+            mSkipNextSDFReinit = true;
+            
+            // Apply the stored SDF coefficients to GEN
+            if ( mPerformerManager->mReinitializePerformer.size() > 0 )
+            {
+                Reinitialize_Performer* tReinitPerformer = mPerformerManager->mReinitializePerformer( 0 ).get();
+                Matrix< DDRMat > const& tCoeffs = tReinitPerformer->get_coefficients();
+                
+                if ( tCoeffs.n_rows() > 0 )
+                {
+                    // Get current ADV count from GEN to verify size matches
+                    Vector< real > const& tCurrentADVs = mPerformerManager->mGENPerformer( 0 )->get_advs();
+                    uint tExpectedSize = tCurrentADVs.size();
+                    uint tStoredSize = tCoeffs.n_rows();
+                    
+                    if ( tStoredSize != tExpectedSize )
+                    {
+                        MORIS_LOG_WARNING( "SDF coefficient count (%d) does not match current ADV count (%d). "
+                                "This can happen if mesh topology changed during reinit. Skipping SDF application.",
+                                (int)tStoredSize, (int)tExpectedSize );
+                    }
+                    else
+                    {
+                        // Convert to Vector for ADVs
+                        Vector< real > tNewADVs( tCoeffs.n_rows() );
+                        for ( uint i = 0; i < tCoeffs.n_rows(); ++i )
+                        {
+                            tNewADVs( i ) = tCoeffs( i );
+                        }
+                        
+                        // Set new ADVs in GEN - these will be picked up by distribute_advs() later
+                        mPerformerManager->mGENPerformer( 0 )->set_advs( tNewADVs );
+                        
+                        MORIS_LOG_INFO( "Applied %d SDF coefficients to GEN in initialize()", (int)tCoeffs.n_rows() );
+                    }
+                }
+            }
+        }
+        
+        // Clear SDF reinit pending flag (coefficients now applied above)
+        mSDFReinitPending = false;
 
         mIter = 0;
 
@@ -215,7 +262,11 @@ namespace moris::wrk
         tOptIter = tOptIter + mIter;
 
         // return vector of design criteria with NANs causing the optimization algorithm to restart
-        if ( mIter >= mReinitializeIterInterval or ( uint ) tOptIter == mReinitializeIterFirst )
+        // Skip this block for INTERFACE_SDF mode - we handle NANs in the SDF reinit block (line ~420)
+        bool tIsInterfaceSDFMode = mPerformerManager->mReinitializePerformer.size() > 0 &&
+                mPerformerManager->mReinitializePerformer( 0 )->get_reinit_mode() == ReinitMode::INTERFACE_SDF;
+        
+        if ( !tIsInterfaceSDFMode && ( mIter >= mReinitializeIterInterval or ( uint ) tOptIter == mReinitializeIterFirst ) )
         {
             mInitializeOptimizationRestart = true;
 
@@ -227,10 +278,12 @@ namespace moris::wrk
         // Stage *: Re-initialization of the adv field
         if ( mPerformerManager->mReinitializePerformer.size() > 0 )
         {
-            // decide if the re-initialization would be required
-            sint tReinitFreq = mPerformerManager->mReinitializePerformer( 0 )->get_reinitialization_frequency();
+            Reinitialize_Performer* tReinitPerformer = mPerformerManager->mReinitializePerformer( 0 ).get();
+            sint tReinitFreq = tReinitPerformer->get_reinitialization_frequency();
 
-            if ( tOptIter > 0 and tOptIter % tReinitFreq == 0 )
+            // FIELD_REMAP mode: reinitialize ADVs from solution field before XTK
+            if ( tReinitPerformer->get_reinit_mode() == ReinitMode::FIELD_REMAP 
+                 && tOptIter > 0 && tOptIter % tReinitFreq == 0 )
             {
                 // Set new advs in GE
                 Tracer tTracer( "GEN", "Levelset", "Re-InitializeADVs" );
@@ -241,6 +294,36 @@ namespace moris::wrk
 
                 // get advs from GE and overwrite them
                 aNewADVs = mPerformerManager->mGENPerformer( 0 )->get_advs();
+            }
+            // INTERFACE_SDF mode: Handle restart after SDF reinit triggered NANs
+            // Apply the stored SDF coefficients when mSDFReinitPending is set
+            else if ( tReinitPerformer->get_reinit_mode() == ReinitMode::INTERFACE_SDF
+                      && mSDFReinitPending )
+            {
+                Tracer tTracer( "GEN", "Levelset", "Interface-SDF-Apply-ADVs" );
+                
+                // Get the stored SDF coefficients and use them as new ADVs
+                Matrix< DDRMat > const& tCoeffs = tReinitPerformer->get_coefficients();
+                
+                if ( tCoeffs.n_rows() > 0 )
+                {
+                    // Convert to Vector for ADVs
+                    Vector< real > tNewADVs( tCoeffs.n_rows() );
+                    for ( uint i = 0; i < tCoeffs.n_rows(); ++i )
+                    {
+                        tNewADVs( i ) = tCoeffs( i );
+                    }
+                    
+                    // Set new ADVs in GEN AND update aNewADVs
+                    // This is safe on restart - optimizer hasn't computed criteria yet
+                    mPerformerManager->mGENPerformer( 0 )->set_advs( tNewADVs );
+                    aNewADVs = tNewADVs;
+                    
+                    MORIS_LOG_INFO( "Applied %zu SDF coefficients as new ADVs", tCoeffs.n_rows() );
+                }
+                
+                // Clear the pending flag - ADVs have been applied
+                mSDFReinitPending = false;
             }
             else
             {
@@ -344,8 +427,34 @@ namespace moris::wrk
             {
                 sint tReinitFreq = tReinitPerformer->get_reinitialization_frequency();
 
-                if ( tOptIter > 0 && tOptIter % tReinitFreq == 0 )
+                // One-time SDF initialization at the first iteration: start the optimizer
+                // from a true signed distance field rather than the raw initial level set.
+                bool tInitAtStart = tReinitPerformer->get_initialize_at_start()
+                                 && !mSDFInitialized && tOptIter > 0;
+
+                // Regular scheduled reinit on the configured frequency
+                bool tScheduled = tOptIter > 0 && tOptIter % tReinitFreq == 0;
+
+                // In-place mode: redistance the field in-place (no restart) every tReinitFreq
+                // iterations (reinitialization_frequency; =1 means every step). Keeps the field near
+                // a true SDF on that cadence; smoothing fires on the same schedule.
+                bool tEveryStep  = tReinitPerformer->get_reinit_every_step();
+                bool tRedistance = tEveryStep ? ( tOptIter > 0 && tOptIter % tReinitFreq == 0 ) : tScheduled;
+                bool tDoSmooth   = tEveryStep ? ( tOptIter % tReinitFreq == 0 ) : true;
+
+                // Skip SDF reinit on restart pass (first iteration after restart)
+                if ( mSkipNextSDFReinit )
                 {
+                    MORIS_LOG_INFO( "Skipping SDF reinit on restart pass" );
+                    mSkipNextSDFReinit = false;
+                }
+                // Trigger SDF reinit: the one-time start-of-run init, every-step redistance, or schedule
+                else if ( ( tInitAtStart || tRedistance ) && !mSDFReinitPending && !mSDFWeanedOff )
+                {
+                    if ( tInitAtStart )
+                    {
+                        MORIS_LOG_INFO( "Initializing design as SDF on first iteration (sdf_initialize_at_start)" );
+                    }
                     Tracer tTracer( "GEN", "Levelset", "Interface-SDF-Reinitialize" );
 
                     // Get XTK cut integration mesh
@@ -366,21 +475,102 @@ namespace moris::wrk
                             tInterpMesh,
                             mPerformerManager->mGENPerformer,
                             mPerformerManager->mMTKPerformer,
-                            tSDFField );
+                            tSDFField,
+                            tDoSmooth );
 
-                    // Distribute new SDF to ADVs
-                    if ( tSDFField != nullptr )
+                    // Every-step in-place redistance: overwrite the ADVs with the redistanced
+                    // coefficients and continue WITHOUT a NaN/restart. The native MMA optimizer
+                    // (cl_OPT_Algorithm_MMA) owns its loop and writes these back into its design
+                    // vector, so the redistanced design persists and the criteria/gradient stay
+                    // consistent. (The TPL GCMMA cannot do this -- it would hit the gradient
+                    // consistency assert -- so every-step mode requires algorithm = "mma".)
+                    // Skipped on iterations where the basis size changed (remesh handled elsewhere).
+                    if ( tSDFField != nullptr && tEveryStep )
                     {
-                        mPerformerManager->mGENPerformer( 0 )->distribute_advs(
-                                mPerformerManager->mMTKPerformer( 0 )->get_mesh_pair( 0 ),
-                                tReinitPerformer->get_mtk_fields() );
+                        Matrix< DDRMat > const& tCoeffs = tReinitPerformer->get_coefficients();
+                        if ( tCoeffs.n_rows() == aNewADVs.size() && aNewADVs.size() > 0 )
+                        {
+                            for ( uint iADV = 0; iADV < tCoeffs.n_rows(); ++iADV )
+                            {
+                                aNewADVs( iADV ) = tCoeffs( iADV );
+                            }
+                            mSDFInitialized = true;
+                            MORIS_LOG_INFO( "SDF redistanced in-place every step (no restart): %u coeffs%s",
+                                    (uint)tCoeffs.n_rows(), tDoSmooth ? ", smoothed" : "" );
+                        }
+                        else
+                        {
+                            MORIS_LOG_INFO( "SDF redistance skipped this step: coeff count %u != ADV count %u (mesh changed)",
+                                    (uint)tCoeffs.n_rows(), (uint)aNewADVs.size() );
+                        }
+                        // no NaN, no restart -- fall through to FEM with the redistanced design
+                    }
+                    // Distribute new SDF to ADVs (restart-based reinit; scheduled mode every reinit_freq)
+                    else if ( tSDFField != nullptr )
+                    {
+                        // Wean-off decision driven by the actual DESIGN-VARIABLE change between
+                        // reinits, ||x_k - x_{k-1}|| / ||x_{k-1}||. Unlike the reinit's field drift
+                        // (which is dominated by |grad phi| re-normalization and stays large), the
+                        // design-variable change genuinely shrinks as GCMMA converges. When it falls
+                        // below the tolerance the design has settled, so applying further reinits
+                        // would only perturb a converged design: disable reinit for the rest of the
+                        // run. Skipped for the one-time start init and the first scheduled reinit
+                        // (no previous design to compare against yet).
+                        real tWeanTol = tReinitPerformer->get_wean_tol();
+                        bool tWeanOff = false;
+                        if ( !tInitAtStart && tWeanTol > 0.0
+                                && mPrevReinitADVs.size() == aNewADVs.size() && aNewADVs.size() > 0 )
+                        {
+                            real tNumer = 0.0;
+                            real tDenom = 0.0;
+                            for ( uint iADV = 0; iADV < aNewADVs.size(); ++iADV )
+                            {
+                                tNumer += std::pow( aNewADVs( iADV ) - mPrevReinitADVs( iADV ), 2 );
+                                tDenom += std::pow( mPrevReinitADVs( iADV ), 2 );
+                            }
+                            real tDVChange = ( tDenom > 0.0 ) ? std::sqrt( tNumer / tDenom ) : 0.0;
+                            tWeanOff = ( tDVChange < tWeanTol );
+                            MORIS_LOG_INFO( "SDF reinit design-variable change: %.4e (wean tol %.4e)%s",
+                                    tDVChange, tWeanTol, tWeanOff ? " -> wean off" : "" );
+                        }
 
-                        // Update ADVs for caller
-                        aNewADVs = mPerformerManager->mGENPerformer( 0 )->get_advs();
+                        // Record the current design as the reference for the next reinit
+                        mPrevReinitADVs = aNewADVs;
+
+                        if ( !tInitAtStart && tWeanOff )
+                        {
+                            MORIS_LOG_INFO( "SDF reinit weaned off: design-variable change below tolerance, no further reinits" );
+                            mSDFWeanedOff = true;
+                        }
+                        else
+                        {
+                            // The design is now a true SDF; the one-time start-of-run
+                            // initialization is satisfied and will not fire again.
+                            mSDFInitialized = true;
+
+                            // Mark that SDF coefficients are pending for NEXT iteration
+                            // They will be applied at the start of the next get_criteria call
+                            // (at lines 247-276) BEFORE XTK runs
+                            mSDFReinitPending = true;
+
+                            MORIS_LOG_INFO( "SDF reinitialization computed, returning NANs to trigger restart" );
+
+                            // Return NaNs to trigger optimizer restart
+                            // On restart, ADVs will be applied BEFORE XTK runs
+                            mInitializeOptimizationRestart = true;
+
+                            // Build and return vector of NANs
+                            Vector< real > tNaNVector( mNumCriteria, std::numeric_limits< real >::quiet_NaN() );
+                            return tNaNVector;  // Exit early - don't continue to FEM
+                        }
                     }
                 }
             }
         }
+
+        // NOTE: mSDFReinitPending is NOT cleared here.
+        // It persists until the next iteration, where it's checked at lines 247-276
+        // and the ADVs are applied BEFORE XTK runs (then the flag is cleared there)
 
         if ( tDeleteXTK )
         {
@@ -500,17 +690,24 @@ namespace moris::wrk
         mPerformerManager->mMDLPerformer( 0 )->perform();
 
         // perform mapping at this stage between solution field and adv field as some data will be deleted
+        // This is FIELD_REMAP mode only - INTERFACE_SDF mode handles reinitialization earlier (after XTK)
         if ( mPerformerManager->mReinitializePerformer.size() > 0 )
         {
-            // decide if we need to perform mapping
-            if ( tOptIter % ( mPerformerManager->mReinitializePerformer( 0 )->get_reinitialization_frequency() ) ==    //
-                    mPerformerManager->mReinitializePerformer( 0 )->get_reinitialization_frequency() - 1 )
+            Reinitialize_Performer* tReinitPerformer = mPerformerManager->mReinitializePerformer( 0 ).get();
+            
+            // Only run perform() for FIELD_REMAP mode
+            if ( tReinitPerformer->get_reinit_mode() == ReinitMode::FIELD_REMAP )
             {
-                // perform mapping of the solution to the adv
-                mPerformerManager->mReinitializePerformer( 0 )->perform( mPerformerManager->mHMRPerformer,
-                        mPerformerManager->mGENPerformer,
-                        mPerformerManager->mMTKPerformer,
-                        mPerformerManager->mMDLPerformer );
+                // decide if we need to perform mapping
+                if ( tOptIter % tReinitPerformer->get_reinitialization_frequency() ==
+                        tReinitPerformer->get_reinitialization_frequency() - 1 )
+                {
+                    // perform mapping of the solution to the adv
+                    mPerformerManager->mReinitializePerformer( 0 )->perform( mPerformerManager->mHMRPerformer,
+                            mPerformerManager->mGENPerformer,
+                            mPerformerManager->mMTKPerformer,
+                            mPerformerManager->mMDLPerformer );
+                }
             }
         }
 

--- a/projects/WRK/src/cl_WRK_Workflow_HMR_XTK.cpp
+++ b/projects/WRK/src/cl_WRK_Workflow_HMR_XTK.cpp
@@ -335,6 +335,53 @@ namespace moris::wrk
         // XTK perform - enrich - ghost - multigrid
         tXTKPerformer->perform_enrichment();
 
+        // Stage *: Interface-based SDF reinitialization (after XTK has interface facets)
+        if ( mPerformerManager->mReinitializePerformer.size() > 0 )
+        {
+            Reinitialize_Performer* tReinitPerformer = mPerformerManager->mReinitializePerformer( 0 ).get();
+
+            if ( tReinitPerformer->get_reinit_mode() == ReinitMode::INTERFACE_SDF )
+            {
+                sint tReinitFreq = tReinitPerformer->get_reinitialization_frequency();
+
+                if ( tOptIter > 0 && tOptIter % tReinitFreq == 0 )
+                {
+                    Tracer tTracer( "GEN", "Levelset", "Interface-SDF-Reinitialize" );
+
+                    // Get XTK cut integration mesh
+                    xtk::Cut_Integration_Mesh* tCutMeshPtr = tXTKPerformer->get_cut_integration_mesh();
+
+                    MORIS_ERROR( tCutMeshPtr != nullptr,
+                            "Workflow_HMR_XTK::perform - Cut integration mesh not available for SDF reinit" );
+
+                    xtk::Cut_Integration_Mesh& tCutMesh = *tCutMeshPtr;
+
+                    // Get interpolation mesh
+                    mtk::Mesh* tInterpMesh = mPerformerManager->mMTKPerformer( 0 )->get_interpolation_mesh( 0 );
+
+                    // Compute SDF from interface and update field
+                    std::shared_ptr< mtk::Field > tSDFField;
+                    tReinitPerformer->compute_sdf_from_interface(
+                            tCutMesh,
+                            tInterpMesh,
+                            mPerformerManager->mGENPerformer,
+                            mPerformerManager->mMTKPerformer,
+                            tSDFField );
+
+                    // Distribute new SDF to ADVs
+                    if ( tSDFField != nullptr )
+                    {
+                        mPerformerManager->mGENPerformer( 0 )->distribute_advs(
+                                mPerformerManager->mMTKPerformer( 0 )->get_mesh_pair( 0 ),
+                                tReinitPerformer->get_mtk_fields() );
+
+                        // Update ADVs for caller
+                        aNewADVs = mPerformerManager->mGENPerformer( 0 )->get_advs();
+                    }
+                }
+            }
+        }
+
         if ( tDeleteXTK )
         {
             // construct the data base with the mtk performer from xtk

--- a/projects/WRK/src/cl_WRK_Workflow_HMR_XTK.hpp
+++ b/projects/WRK/src/cl_WRK_Workflow_HMR_XTK.hpp
@@ -58,6 +58,21 @@ namespace moris
         class Workflow_HMR_XTK : public Workflow
         {
           private:
+            /// Flag to track that SDF reinit has triggered NANs and coefficients are pending
+            bool mSDFReinitPending = false;
+            
+            /// Flag to skip SDF reinit on the first iteration after restart
+            bool mSkipNextSDFReinit = false;
+
+            /// Flag to track that the one-time start-of-run SDF initialization has fired
+            bool mSDFInitialized = false;
+
+            /// Flag to permanently disable SDF reinit once it has weaned off (design converged)
+            bool mSDFWeanedOff = false;
+
+            /// Design variables (ADVs) captured at the previous scheduled reinit, used to measure
+            /// the design-variable change between reinits for the wean-off decision
+            Vector< real > mPrevReinitADVs;
 
           public:
             //------------------------------------------------------------------------------

--- a/projects/WRK/src/fn_WRK_Workflow_Main_Interface.cpp
+++ b/projects/WRK/src/fn_WRK_Workflow_Main_Interface.cpp
@@ -35,7 +35,11 @@
 #include "linalg_typedefs.hpp"
 #include "op_move.hpp"
 
-#include "cl_Logger.hpp"    // MRS/IOS/src
+#include "cl_Logger.hpp"                  // MRS/IOS/src
+#include "cl_Performance_Reporter.hpp"    // MRS/IOS/src
+#include "cl_Profiler.hpp"                // MRS/CHR/src
+
+#include <memory>
 
 #include "cl_WRK_Workflow_Factory.hpp"
 #include "cl_WRK_Performer_Manager.hpp"
@@ -69,6 +73,12 @@ int fn_WRK_Workflow_Main_Interface( int argc, char *argv[] )
     bool        tSoFileSpecified  = false;
     bool        tXmlFileSpecified = false;
 
+    // performance-report overrides provided on the command line
+    sint        tCliPerfLevel    = 0;
+    bool        tCliPerfLevelSet = false;
+    std::string tCliPerfFile     = "";
+    bool        tCliPerfFileSet  = false;
+
     // go through user arguments and look for flags
     for ( int k = 1; k < argc; ++k )
     {
@@ -82,6 +92,8 @@ int fn_WRK_Workflow_Main_Interface( int argc, char *argv[] )
             MORIS_LOG( "Valid input arguments are:" );
             MORIS_LOG( "option       : --meshgen or -mg :  generate foreground and background meshes (for EXHUME project)" );
             MORIS_LOG( "option       : --pause   or -p  :  report process IDs and pause run upon user input (for debugging)" );
+            MORIS_LOG( "option       : --perf-level N   :  performance-report granularity (0=run total .. 3=full tree, <0 off)" );
+            MORIS_LOG( "option       : --perf-report F  :  path of the JSON performance report" );
             MORIS_LOG( "last argument: <filename>.so    :  objective file with MORIS input" );
             MORIS_LOG( "last argument: <filename>.xml   :  xml file with MORIS input" );
             MORIS_LOG( " " );
@@ -95,6 +107,28 @@ int fn_WRK_Workflow_Main_Interface( int argc, char *argv[] )
         {
             tIsOnlyMeshing = true;
             MORIS_LOG( "Only mesh generation and output requested." );
+            continue;
+        }
+
+        // performance-report granularity override: --perf-level N
+        if ( tArgString == "--perf-level" )
+        {
+            if ( k + 1 < argc )
+            {
+                tCliPerfLevel    = std::atoi( argv[ ++k ] );
+                tCliPerfLevelSet = true;
+            }
+            continue;
+        }
+
+        // performance-report file override: --perf-report <path>
+        if ( tArgString == "--perf-report" )
+        {
+            if ( k + 1 < argc )
+            {
+                tCliPerfFile    = std::string( argv[ ++k ] );
+                tCliPerfFileSet = true;
+            }
             continue;
         }
 
@@ -195,6 +229,47 @@ int fn_WRK_Workflow_Main_Interface( int argc, char *argv[] )
         MORIS_ERROR( tOPTParameterList.size() > 0,
                 "fn_WRK_Workflow_Main_Interface: OPT parameter not set but are required." );
 
+        // resolve the performance-report configuration: OPT parameter list, overridden
+        // by the MORIS_PERF_LEVEL environment variable, overridden by the --perf-level CLI flag.
+        // Guard with exists() so decks predating these parameters still run (get() would error).
+        sint        tPerfLevel = 1;
+        std::string tPerfFile  = "perf_report.json";
+
+        if ( tOPTParameterList( 0 )( 0 ).exists( "performance_report_level" ) )
+        {
+            tPerfLevel = tOPTParameterList( 0 )( 0 ).get< sint >( "performance_report_level" );
+        }
+        if ( tOPTParameterList( 0 )( 0 ).exists( "performance_report_file" ) )
+        {
+            tPerfFile = tOPTParameterList( 0 )( 0 ).get< std::string >( "performance_report_file" );
+        }
+
+        if ( const char* tEnvLevel = std::getenv( "MORIS_PERF_LEVEL" ) )
+        {
+            tPerfLevel = std::atoi( tEnvLevel );
+        }
+        if ( tCliPerfLevelSet )
+        {
+            tPerfLevel = tCliPerfLevel;
+        }
+        if ( tCliPerfFileSet )
+        {
+            tPerfFile = tCliPerfFile;
+        }
+
+        // a negative level disables the report entirely
+        if ( tPerfLevel >= 0 )
+        {
+            gPerfReporter.initialize( tPerfLevel, tPerfFile );
+        }
+
+        // at the deepest granularity, also capture a gperftools CPU profile (callgrind)
+        // of the whole run; a no-op unless MORIS is built with gperftools
+#ifdef WITHGPERFTOOLS
+        std::unique_ptr< moris::Profiler > tProfiler =
+                tPerfLevel >= 3 ? std::make_unique< moris::Profiler >( "/tmp/gprofmoris.log" ) : nullptr;
+#endif
+
         // Create performer manager
         wrk::Performer_Manager tPerformerManager( tLibrary );
 
@@ -221,6 +296,14 @@ int fn_WRK_Workflow_Main_Interface( int argc, char *argv[] )
             // print out matrix of IQI values
             MORIS_LOG_SPEC( "IQI values", ios::stringify_log( tIQIVal ) );
         }
+
+        // finalize the gperftools CPU profile (writes the callgrind file)
+#ifdef WITHGPERFTOOLS
+        if ( tProfiler )
+        {
+            tProfiler->stop();
+        }
+#endif
     }
 
     // return success

--- a/projects/XTK/src/cl_XTK_Cut_Integration_Mesh.cpp
+++ b/projects/XTK/src/cl_XTK_Cut_Integration_Mesh.cpp
@@ -603,6 +603,11 @@ namespace moris::xtk
             mtk::EntityRank aEntityRank,
             moris_index     aDiscretizationIndex ) const
     {
+        // NOTE: this returns the local INDEX as the "global id" (get_index(), not get_id()),
+        // while the inverse query get_loc_entity_ind_from_entity_glb_id() is keyed by the
+        // REAL ids (mIntegrationVertexIdToIndexMap / mIntegrationCellIdToIndexMap), so the
+        // round trip is inconsistent and the answer collides across processors in parallel.
+        // See share/doc/Dev_XTK_Ids_And_Indices.dox; audit callers before changing to get_id().
         MORIS_ERROR( aEntityRank == mtk::EntityRank::NODE || aEntityRank == mtk::EntityRank::ELEMENT, "Only supported for nodes and cells" );
         if ( aEntityRank == mtk::EntityRank::NODE )
         {

--- a/projects/mains/main.cpp
+++ b/projects/mains/main.cpp
@@ -12,9 +12,10 @@
 #include <ios>
 #include <limits>
 
-#include "cl_Communication_Manager.hpp"    // COM/src
-#include "cl_Logger.hpp"                   // MRS/IOS/src
-#include "banner.hpp"                      // COR/src
+#include "cl_Communication_Manager.hpp"      // COM/src
+#include "cl_Logger.hpp"                     // MRS/IOS/src
+#include "cl_Performance_Reporter.hpp"       // MRS/IOS/src
+#include "banner.hpp"                        // COR/src
 #include <Kokkos_Core.hpp>
 
 moris::Comm_Manager gMorisComm;
@@ -86,6 +87,9 @@ int main( int argc, char* argv[] )
     int tRet = fn_WRK_Workflow_Main_Interface( argc, argv );
 
     // Kokkos::finalize_all();
+
+    // emit the consolidated performance report (while MPI is still live for cross-rank reduction)
+    gPerfReporter.finalize();
 
     // finalize MORIS global communication manager
     gMorisComm.finalize();

--- a/share/doc/Dev_XTK_Ids_And_Indices.dox
+++ b/share/doc/Dev_XTK_Ids_And_Indices.dox
@@ -1,0 +1,86 @@
+#
+# Copyright (c) 2022 University of Colorado
+# Licensed under the MIT license. See LICENSE.txt file in the MORIS root for details.
+#
+#------------------------------------------------------------------------------------
+#
+
+namespace moris{
+
+/** @defgroup XTKIdsIndices XTK/MTK: Global IDs vs Local Indices
+
+@section IdsIndicesDefs Definitions
+
+- A local <b>INDEX</b> (\c moris_index) is 0-based, processor-local, and contiguous: it is
+  the entity's position in the owning container (e.g.
+  \c Cut_Integration_Mesh::mIntegrationVertices). Indices are the fast handle used in
+  loops and connectivity construction; they are meaningless across processors and across
+  meshes.
+
+- A <b>GLOBAL ID</b> (\c moris_id) is parallel-unique and not necessarily contiguous, and
+  in MORIS it is <b>0-based</b>: background meshes hand out ids starting at 0, and XTK
+  allocates ids for newly created entities by continuing after the background maximum
+  (\c Cut_Integration_Mesh::mGlobalMaxVertexId is seeded with
+  <tt>background max id + 1</tt> and advanced through the parallel-coordinated
+  gather/scatter in \c Cut_Integration_Mesh::allocate_entity_ids). After cutting, cell id
+  ranges are sparse: parents that were replaced by children leave gaps.
+
+Rule of thumb: use <tt>get_index()</tt> for container access, loops, and connectivity;
+use <tt>get_id()</tt> for anything parallel-global — maps shared across processors,
+communication, and file output. Never feed indices into an id map.
+
+@section IdsIndicesExodus The Exodus boundary: ids are written +1
+
+The Exodus II format requires id-map entries to be <b>positive</b> (1-based); an id of 0
+is invalid. MORIS's 0-based global ids therefore cannot be written verbatim.
+\c mtk::Writer_Exodus consequently writes <tt>moris_id + 1</tt> into \c EX_NODE_MAP and
+\c EX_ELEM_MAP — the same +1 convention the writer has always used for connectivity. In
+any MORIS-written exodus file:
+
+<tt>exodus user id == moris_id + 1</tt>
+
+Tools that map exodus ids back to MORIS ids must subtract 1. So that readers can tell
+MORIS files from everything else, \c mtk::Writer_Exodus stamps every file with the QA
+record <tt>"MORIS | exodus_ids=moris_id+1"</tt>, and
+\c mtk::Exodus_IO_Helper detects the stamp at open: its by-id lookup
+(\c get_node_index_by_Id, used by \c mtk::Field::load_field_from_exodus and the EXA
+reference checks \c get_nodal_field_value / \c get_nodal_coordinate) takes a
+<em>MORIS</em> id and searches the file's map for <tt>id + 1</tt> <b>only on stamped
+files</b>. Unstamped files — external meshes (e.g. Cubit fixtures, whose 1-based ids ARE
+the MORIS ids once read through STK) and files written by pre-stamp MORIS binaries — are
+queried verbatim, i.e. exactly the pre-fix behavior. Consequence: all three file
+populations read correctly, and hard-coded reference node ids in the EXA tests keep
+addressing the same physical nodes everywhere.
+
+<b>Why this matters (observed with ParaView 5.11):</b> IOSS-based readers (ParaView's
+default exodus reader, modern SEACAS tools) validate the id maps lazily on first use and
+<em>drop whichever element block they happen to be reading when validation fails</em> —
+not necessarily the block containing the offending id. On a 4-block XTK output this
+silently yields a partial mesh (the cut blocks vanished); on a 2-block output the mesh is
+fully degenerate (0 cells).
+
+<b>Files written before this fix (pre 2026-07)</b> carry 0-based maps. To view them:
+load the \c LegacyExodusReader plugin (Tools &gt; Manage Plugins) and open the file with
+the legacy "Exodus II" reader, which tolerates 0-based maps for display; or repair a copy
+of the file (pvtools: <tt>pvkit.load(..., fix_ids=True)</tt> /
+<tt>pvkit.fix_zero_global_ids</tt>) and use any reader. The repair is required for the
+default IOSS reader and for anything keyed on global ids (Find Data by GlobalID,
+id labeling, re-export).
+
+@section IdsIndicesConflation Known conflation in Cut_Integration_Mesh
+
+\c Cut_Integration_Mesh::get_glb_entity_id_from_entity_loc_index() currently returns
+<tt>get_index()</tt> — the local index — not <tt>get_id()</tt>, while the inverse query
+\c get_loc_entity_ind_from_entity_glb_id() is keyed by the <em>real</em> ids
+(\c mIntegrationVertexIdToIndexMap / \c mIntegrationCellIdToIndexMap). The round trip
+id &rarr; index &rarr; id is therefore inconsistent, and in parallel the index-as-id
+answer collides across processors (it only "works" serially because indices and 0-based
+ids are nearly interchangeable there). \c vis::Visualization_Mesh implements the same
+query correctly (returns <tt>get_id()</tt>).
+
+Changing the XTK query to return <tt>get_id()</tt> is a known TODO: audit callers first —
+code built against the current behavior may rely on receiving indices.
+
+*/
+
+}


### PR DESCRIPTION
## Summary

The performance-report feature branch, rebased onto develop (EXA-runner and matrix-move duplicates dropped in the rebase; 18 commits remain). Content by area:

- **IOS**: consolidated per-module run performance report (`feat(ios)`), with the runner's `gPerfReporter.finalize()` restored in `EXA-test`'s main — completing the note left in PR #4's develop-adaptation commit
- **OPT**: native GCMMA optimizer (`Algorithm_MMA`); uniform objective scaling guarding MMA subproblems against degenerate-cut gradients; recovery from non-finite iterates via restart; parameter-gated gradient clip (default off); self-calibrating clip for exploding XFEM design sensitivities
- **GEN/SDF + WRK**: interface-based SDF reinitialization (`SDF_From_Interface` + unit tests + icosphere/gradient-magnitude verification), integrated into the HMR_XTK workflow with every-step in-place reinit, NaN guard, and wean-off; `sdf_reinit_*` parameters exposed through PRM
- **SOL/DLA**: Block-Krylov-Schur eigensolve robustness on cut problems
- **MTK**: 1-based exodus id maps with QA id-convention stamp
- Docs/skills + gitignore for exodus per-iteration series files

## Notes

- `runner_main.cpp` after the rebase is byte-identical to the version this branch has carried through all EXA-migration verification builds (the only hand-resolved rebase conflict was restoring the two perf-reporter lines the develop adaptation had removed).
- These commits are the branch this work was developed and run on for weeks (all thesis/study runs since mid-June), rebased without content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)