### PR TITLE
feat(OPT): add Trilinos ROL trust-region optimizer (Algorithm_ROL)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,9 @@ option(MORIS_HAVE_SNOPT
 option(MORIS_HAVE_LBFGS
     "Build MORIS with support for LBFGS." ON )
 
+option(MORIS_HAVE_ROL
+    "Build MORIS with support for the Trilinos ROL optimizer." ON )
+
 option(MORIS_HAVE_ARBORX
     "Build MORIS with support for ArborX." ON )
     
@@ -843,6 +846,14 @@ endif()
 
 if (MORIS_HAVE_LBFGS)
     list(APPEND MORIS_DEFINITIONS "-DMORIS_HAVE_LBFGS")
+endif()
+
+# -------------------------------------------------------------------------
+# ROL ---------------------------------------------------------------------
+# -------------------------------------------------------------------------
+
+if (MORIS_HAVE_ROL)
+    list(APPEND MORIS_DEFINITIONS "-DMORIS_HAVE_ROL")
 endif()
 
 # -------------------------------------------------------------------------

--- a/projects/OPT/src/CMakeLists.txt
+++ b/projects/OPT/src/CMakeLists.txt
@@ -19,6 +19,7 @@ set(HEADERS
     cl_OPT_Algorithm_LBFGS.hpp
     cl_OPT_Algorithm_SQP.hpp
     cl_OPT_Algorithm_Sweep.hpp
+    cl_OPT_Algorithm_ROL.hpp
     cl_OPT_Manager.hpp
     cl_OPT_Problem.hpp
     cl_OPT_Criteria_Interface.hpp
@@ -39,6 +40,7 @@ set(LIB_SOURCES
     cl_OPT_Algorithm_LBFGS.cpp
     cl_OPT_Algorithm_SQP.cpp
     cl_OPT_Algorithm_Sweep.cpp
+    cl_OPT_Algorithm_ROL.cpp
     cl_OPT_Manager.cpp
     cl_OPT_Problem.cpp
     cl_OPT_Criteria_Interface.cpp

--- a/projects/OPT/src/cl_OPT_Algorithm_ROL.cpp
+++ b/projects/OPT/src/cl_OPT_Algorithm_ROL.cpp
@@ -1,0 +1,503 @@
+/*
+ * Copyright (c) 2022 University of Colorado
+ * Licensed under the MIT license. See LICENSE.txt file in the MORIS root for details.
+ *
+ *------------------------------------------------------------------------------------
+ *
+ * cl_OPT_Algorithm_ROL.cpp
+ *
+ */
+
+#include "cl_OPT_Algorithm_ROL.hpp"
+#include "cl_Communication_Tools.hpp"
+
+// Logger package
+#include "cl_Logger.hpp"
+#include "cl_Tracer.hpp"
+
+#include <iostream>
+
+// Third party header files
+#ifdef MORIS_HAVE_ROL
+#include "ROL_Ptr.hpp"
+#include "ROL_Types.hpp"
+#include "ROL_ParameterList.hpp"
+#include "ROL_StdVector.hpp"
+#include "ROL_Bounds.hpp"
+#include "ROL_Objective.hpp"
+#include "ROL_Constraint.hpp"
+#include "ROL_Problem.hpp"
+#include "ROL_Solver.hpp"
+#endif
+
+using namespace moris;
+
+namespace moris::opt
+{
+#ifdef MORIS_HAVE_ROL
+    namespace
+    {
+        //--------------------------------------------------------------------------------------------------------------
+        // Small helpers to read/write a MORIS ADV std::vector out of a ROL::Vector (always a StdVector here).
+
+        inline const std::vector< real >&
+        rol_std_vector( const ROL::Vector< real >& aVector )
+        {
+            return *dynamic_cast< const ROL::StdVector< real >& >( aVector ).getVector();
+        }
+
+        inline std::vector< real >&
+        rol_std_vector( ROL::Vector< real >& aVector )
+        {
+            return *dynamic_cast< ROL::StdVector< real >& >( aVector ).getVector();
+        }
+
+        //--------------------------------------------------------------------------------------------------------------
+        // ROL objective adapter: forwards value()/gradient() into the MORIS Problem via the Algorithm.
+
+        class Moris_ROL_Objective : public ROL::Objective< real >
+        {
+          private:
+            Algorithm_ROL* mAlgorithm;
+
+          public:
+            explicit Moris_ROL_Objective( Algorithm_ROL* aAlgorithm )
+                    : mAlgorithm( aAlgorithm )
+            {
+            }
+
+            // ROL signals the disposition of a design point here; write the restart file only when
+            // this point becomes the new accepted iterate (not for the many trial evaluations).
+            void
+            update( const ROL::Vector< real >& aX, ROL::UpdateType aType, int aIter ) override
+            {
+                if ( aType == ROL::UpdateType::Accept || aType == ROL::UpdateType::Initial )
+                {
+                    mAlgorithm->notify_accepted_step( rol_std_vector( aX ) );
+                }
+            }
+
+            real
+            value( const ROL::Vector< real >& aX, real& aTol ) override
+            {
+                mAlgorithm->ensure_criteria( rol_std_vector( aX ) );
+
+                return mAlgorithm->get_objectives()( 0 );
+            }
+
+            void
+            gradient( ROL::Vector< real >& aG, const ROL::Vector< real >& aX, real& aTol ) override
+            {
+                mAlgorithm->ensure_gradients( rol_std_vector( aX ) );
+
+                const Matrix< DDRMat >& tObjectiveGradient = mAlgorithm->get_objective_gradients();
+
+                std::vector< real >& tG = rol_std_vector( aG );
+                for ( uint iADV = 0; iADV < tG.size(); ++iADV )
+                {
+                    tG[ iADV ] = tObjectiveGradient( iADV );
+                }
+            }
+        };
+
+        //--------------------------------------------------------------------------------------------------------------
+        // ROL constraint adapter: the full MORIS constraint vector g(x) and its dense Jacobian
+        // d g_i / d adv_j. Sign convention matches MORIS directly (no flip): equality constraints
+        // are g_i = 0 and inequality constraints are g_i <= 0; the equality-vs-inequality distinction
+        // is carried by the bound placed on the constraint output in rol_solve (eq -> [0,0],
+        // ineq -> [-inf,0]), so this adapter is sign-convention agnostic.
+
+        class Moris_ROL_Constraint : public ROL::Constraint< real >
+        {
+          private:
+            Algorithm_ROL* mAlgorithm;
+
+          public:
+            explicit Moris_ROL_Constraint( Algorithm_ROL* aAlgorithm )
+                    : mAlgorithm( aAlgorithm )
+            {
+            }
+
+            void
+            value( ROL::Vector< real >& aC, const ROL::Vector< real >& aX, real& aTol ) override
+            {
+                mAlgorithm->ensure_criteria( rol_std_vector( aX ) );
+
+                const Matrix< DDRMat >& tConstraints = mAlgorithm->get_constraints();
+
+                std::vector< real >& tC = rol_std_vector( aC );
+                for ( uint iCon = 0; iCon < tC.size(); ++iCon )
+                {
+                    tC[ iCon ] = tConstraints( iCon );
+                }
+            }
+
+            void
+            applyJacobian(
+                    ROL::Vector< real >&       aJv,
+                    const ROL::Vector< real >& aV,
+                    const ROL::Vector< real >& aX,
+                    real&                      aTol ) override
+            {
+                mAlgorithm->ensure_gradients( rol_std_vector( aX ) );
+
+                const Matrix< DDRMat >& tJacobian = mAlgorithm->get_constraint_gradients();    // nCon x nADV
+
+                const std::vector< real >& tV  = rol_std_vector( aV );     // nADV
+                std::vector< real >&       tJv = rol_std_vector( aJv );    // nCon
+
+                for ( uint iCon = 0; iCon < tJv.size(); ++iCon )
+                {
+                    real tSum = 0.0;
+                    for ( uint jADV = 0; jADV < tV.size(); ++jADV )
+                    {
+                        tSum += tJacobian( iCon, jADV ) * tV[ jADV ];
+                    }
+                    tJv[ iCon ] = tSum;
+                }
+            }
+
+            void
+            applyAdjointJacobian(
+                    ROL::Vector< real >&       aAjv,
+                    const ROL::Vector< real >& aV,
+                    const ROL::Vector< real >& aX,
+                    real&                      aTol ) override
+            {
+                mAlgorithm->ensure_gradients( rol_std_vector( aX ) );
+
+                const Matrix< DDRMat >& tJacobian = mAlgorithm->get_constraint_gradients();    // nCon x nADV
+
+                const std::vector< real >& tV   = rol_std_vector( aV );      // nCon
+                std::vector< real >&       tAjv = rol_std_vector( aAjv );    // nADV
+
+                for ( uint jADV = 0; jADV < tAjv.size(); ++jADV )
+                {
+                    real tSum = 0.0;
+                    for ( uint iCon = 0; iCon < tV.size(); ++iCon )
+                    {
+                        tSum += tJacobian( iCon, jADV ) * tV[ iCon ];
+                    }
+                    tAjv[ jADV ] = tSum;
+                }
+            }
+        };
+
+        //--------------------------------------------------------------------------------------------------------------
+
+    }    // namespace
+#endif
+
+    //----------------------------------------------------------------------------------------------------------------------
+
+    Algorithm_ROL::Algorithm_ROL( const Parameter_List& aParameterList )
+            : mStepType( aParameterList.get< std::string >( "step_type" ) )
+            , mSubproblemModel( aParameterList.get< std::string >( "subproblem_model" ) )
+            , mSubproblemSolver( aParameterList.get< std::string >( "subproblem_solver" ) )
+            , mSecantType( aParameterList.get< std::string >( "secant_type" ) )
+            , mSecantStorage( aParameterList.get< sint >( "secant_storage" ) )
+            , mInitialTRRadius( aParameterList.get< real >( "initial_tr_radius" ) )
+            , mMaxTRRadius( aParameterList.get< real >( "max_tr_radius" ) )
+            , mUseAugmentedLagrangian( aParameterList.get< bool >( "use_augmented_lagrangian" ) )
+            , mSubproblemIterationLimit( aParameterList.get< sint >( "subproblem_iteration_limit" ) )
+            , mALInitialPenalty( aParameterList.get< real >( "al_initial_penalty" ) )
+            , mALPenaltyGrowth( aParameterList.get< real >( "al_penalty_growth" ) )
+            , mGradientTol( aParameterList.get< real >( "gradient_tol" ) )
+            , mConstraintTol( aParameterList.get< real >( "constraint_tol" ) )
+            , mStepTol( aParameterList.get< real >( "step_tol" ) )
+            , mXmlFile( aParameterList.get< std::string >( "xml_file" ) )
+    {
+#ifndef MORIS_HAVE_ROL
+        MORIS_ERROR( false, "MORIS was compiled without ROL support" );
+#endif
+
+        mRestartIndex         = aParameterList.get< sint >( "restart_index" );
+        mMaxIterationsInitial = aParameterList.get< sint >( "max_its" );
+        mMaxIterations        = mMaxIterationsInitial;
+
+        MORIS_LOG_INFO( "ROL initialized: step='%s', subproblem_model='%s', max_its=%d",
+                mStepType.c_str(), mSubproblemModel.c_str(), (int)mMaxIterations );
+    }
+
+    //----------------------------------------------------------------------------------------------------------------------
+
+    Algorithm_ROL::~Algorithm_ROL()
+    {
+    }
+
+    //----------------------------------------------------------------------------------------------------------------------
+
+    uint
+    Algorithm_ROL::solve(
+            uint                       aCurrentOptAlgInd,
+            std::shared_ptr< Problem > aOptProb )
+    {
+        // Trace optimization
+        Tracer tTracer( "OptimizationAlgorithm", "ROL", "Solve" );
+
+        // running status has to be wait when starting a solve
+        mRunning = opt::Task::wait;
+
+        mCurrentOptAlgInd = aCurrentOptAlgInd;    // set index of current optimization algorithm
+        mProblem          = aOptProb;             // set the member variable mProblem to aOptProb
+
+        // fresh solve: invalidate the evaluation cache
+        mHaveCriteria  = false;
+        mHaveGradients = false;
+
+        // Set optimization iteration index for restart
+        if ( mRestartIndex > 0 )
+        {
+            gLogger.set_opt_iteration( mRestartIndex );
+        }
+
+        // Solve optimization problem
+        if ( par_rank() == 0 )
+        {
+            // Run ROL algorithm
+            this->rol_solve();
+
+            // Communicate that optimization has finished
+            mRunning = opt::Task::exit;
+
+            this->communicate_running_status();
+        }
+        else
+        {
+            // Run dummy solve (follows rank 0's forward/gradient broadcasts until exit)
+            this->dummy_solve();
+        }
+
+        uint tOptIter = gLogger.get_opt_iteration();
+
+        gLogger.set_iteration( "OPT", "Manager", "Perform", tOptIter );
+
+        return tOptIter;
+    }
+
+    //----------------------------------------------------------------------------------------------------------------------
+
+    void
+    Algorithm_ROL::notify_accepted_step( const std::vector< real >& aADVs )
+    {
+        Vector< real > tADVs( aADVs.size() );
+        for ( uint iADV = 0; iADV < aADVs.size(); ++iADV )
+        {
+            tADVs( iADV ) = aADVs[ iADV ];
+        }
+
+        this->write_advs_to_file( tADVs );
+    }
+
+    //----------------------------------------------------------------------------------------------------------------------
+
+    void
+    Algorithm_ROL::ensure_criteria( const std::vector< real >& aADVs )
+    {
+        // skip the forward solve if criteria are already current at these ADVs
+        if ( mHaveCriteria && aADVs == mCriteriaADVs )
+        {
+            return;
+        }
+
+        // copy into a MORIS ADV vector
+        Vector< real > tADVs( aADVs.size() );
+        for ( uint iADV = 0; iADV < aADVs.size(); ++iADV )
+        {
+            tADVs( iADV ) = aADVs[ iADV ];
+        }
+
+        // Compute the design criteria. NOTE: unlike GCMMA/SQP we do NOT write a restart file here.
+        // ROL evaluates the objective at many trial (rejected) points per iteration, so a per-eval
+        // restart write would emit hundreds of large HDF5 files; the restart is written only on
+        // ACCEPTED steps via notify_accepted_step (called from the objective adapter's update()).
+        this->compute_design_criteria( tADVs );
+
+        mCriteriaADVs  = aADVs;
+        mHaveCriteria  = true;
+        mHaveGradients = false;    // criteria changed -> cached gradients are stale
+    }
+
+    //----------------------------------------------------------------------------------------------------------------------
+
+    void
+    Algorithm_ROL::ensure_gradients( const std::vector< real >& aADVs )
+    {
+        // the adjoint reuses the forward state, so make sure criteria are current first
+        this->ensure_criteria( aADVs );
+
+        // skip the adjoint solve if gradients are already current at these ADVs
+        if ( mHaveGradients && aADVs == mGradientADVs )
+        {
+            return;
+        }
+
+        Vector< real > tADVs( aADVs.size() );
+        for ( uint iADV = 0; iADV < aADVs.size(); ++iADV )
+        {
+            tADVs( iADV ) = aADVs[ iADV ];
+        }
+
+        this->compute_design_criteria_gradients( tADVs );
+
+        mGradientADVs  = aADVs;
+        mHaveGradients = true;
+    }
+
+    //----------------------------------------------------------------------------------------------------------------------
+
+    void
+    Algorithm_ROL::rol_solve()
+    {
+#ifdef MORIS_HAVE_ROL
+        const uint tNumADVs = mProblem->get_num_advs();
+
+        // --- design vector and bounds as ROL StdVectors backed by std::vectors -------------------
+        auto tAdvVec = ROL::makePtr< std::vector< real > >( tNumADVs );
+        auto tLoVec  = ROL::makePtr< std::vector< real > >( tNumADVs );
+        auto tHiVec  = ROL::makePtr< std::vector< real > >( tNumADVs );
+
+        for ( uint iADV = 0; iADV < tNumADVs; ++iADV )
+        {
+            ( *tAdvVec )[ iADV ] = mProblem->get_advs()( iADV );
+            ( *tLoVec )[ iADV ]  = mProblem->get_lower_bounds()( iADV );
+            ( *tHiVec )[ iADV ]  = mProblem->get_upper_bounds()( iADV );
+        }
+
+        ROL::Ptr< ROL::Vector< real > > tX     = ROL::makePtr< ROL::StdVector< real > >( tAdvVec );
+        ROL::Ptr< ROL::Vector< real > > tLower = ROL::makePtr< ROL::StdVector< real > >( tLoVec );
+        ROL::Ptr< ROL::Vector< real > > tUpper = ROL::makePtr< ROL::StdVector< real > >( tHiVec );
+
+        ROL::Ptr< ROL::BoundConstraint< real > > tBounds =
+                ROL::makePtr< ROL::Bounds< real > >( tLower, tUpper );
+
+        // --- objective adapter -------------------------------------------------------------------
+        ROL::Ptr< ROL::Objective< real > > tObjective =
+                ROL::makePtr< Moris_ROL_Objective >( this );
+
+        // --- assemble the ROL problem (bound-constrained; general constraints added in M2) -------
+        ROL::Ptr< ROL::Problem< real > > tRolProblem =
+                ROL::makePtr< ROL::Problem< real > >( tObjective, tX );
+        tRolProblem->addBoundConstraint( tBounds );
+
+        // --- general constraints (Augmented-Lagrangian outer loop) -------------------------------
+        const uint tNumConstraints = mProblem->get_num_constraints();
+        const bool tUseConstraints = ( tNumConstraints > 0 ) && mUseAugmentedLagrangian;
+
+        if ( tNumConstraints > 0 && !mUseAugmentedLagrangian )
+        {
+            MORIS_LOG_WARNING( "ROL: %d constraint(s) present but use_augmented_lagrangian=false; "
+                               "solving bound-constrained and IGNORING the general constraints.",
+                    (int)tNumConstraints );
+        }
+
+        if ( tUseConstraints )
+        {
+            // Bounds on the constraint output encode the MORIS constraint types:
+            //   equality   (type 0): g_i = 0    -> [ 0, 0 ]
+            //   inequality (type 1): g_i <= 0   -> [ -inf, 0 ]
+            Matrix< DDSMat > tConstraintTypes = mProblem->get_constraint_types();
+
+            auto tConLo = ROL::makePtr< std::vector< real > >( tNumConstraints );
+            auto tConHi = ROL::makePtr< std::vector< real > >( tNumConstraints );
+            for ( uint iCon = 0; iCon < tNumConstraints; ++iCon )
+            {
+                ( *tConHi )[ iCon ] = 0.0;
+                ( *tConLo )[ iCon ] = ( tConstraintTypes( iCon ) == 0 ) ? 0.0 : -ROL::ROL_INF< real >();
+            }
+
+            ROL::Ptr< ROL::Vector< real > > tConLoV = ROL::makePtr< ROL::StdVector< real > >( tConLo );
+            ROL::Ptr< ROL::Vector< real > > tConHiV = ROL::makePtr< ROL::StdVector< real > >( tConHi );
+            ROL::Ptr< ROL::BoundConstraint< real > > tConBound =
+                    ROL::makePtr< ROL::Bounds< real > >( tConLoV, tConHiV );
+
+            ROL::Ptr< ROL::Constraint< real > > tConstraint =
+                    ROL::makePtr< Moris_ROL_Constraint >( this );
+
+            auto tMulVec = ROL::makePtr< std::vector< real > >( tNumConstraints, 0.0 );
+            ROL::Ptr< ROL::Vector< real > > tMultiplier = ROL::makePtr< ROL::StdVector< real > >( tMulVec );
+
+            tRolProblem->addConstraint( "constraint", tConstraint, tMultiplier, tConBound );
+        }
+
+        // --- parameter list: XML passthrough, else curated trust-region / Lin-More keys ----------
+        ROL::ParameterList tParameterList;
+
+        if ( !mXmlFile.empty() )
+        {
+            ROL::Ptr< ROL::ParameterList > tXmlParameters = ROL::getParametersFromXmlFile( mXmlFile );
+            tParameterList                                = *tXmlParameters;
+        }
+        else
+        {
+            // Print ROL's iteration history (the Lin-More trust-region table: value, gnorm, snorm,
+            // trust-region radius delta, #fval/#grad, tr_flag/iterCG) so the trust-region behavior
+            // on the immersed problem can be harvested. Level 1 = per-iteration history.
+            tParameterList.sublist( "General" ).set( "Output Level", 1 );
+
+            ROL::ParameterList& tStep = tParameterList.sublist( "Step" );
+            // With general constraints, drive an Augmented-Lagrangian outer loop whose inner
+            // subproblem is the (bound-constrained) trust region below; otherwise a plain TR.
+            tStep.set( "Type", tUseConstraints ? std::string( "Augmented Lagrangian" ) : mStepType );
+
+            ROL::ParameterList& tTrustRegion = tStep.sublist( "Trust Region" );
+            tTrustRegion.set( "Subproblem Model", mSubproblemModel );
+            tTrustRegion.set( "Subproblem Solver", mSubproblemSolver );
+            tTrustRegion.set( "Initial Radius", mInitialTRRadius );
+            tTrustRegion.set( "Maximum Radius", mMaxTRRadius );
+
+            if ( tUseConstraints )
+            {
+                ROL::ParameterList& tAugLag = tStep.sublist( "Augmented Lagrangian" );
+                tAugLag.set( "Initial Penalty Parameter", mALInitialPenalty );
+                tAugLag.set( "Penalty Parameter Growth Factor", mALPenaltyGrowth );
+                tAugLag.set( "Subproblem Step Type", "Trust Region" );
+                // Cap the inner (bound-constrained TR) subproblem so each AL outer iteration does a
+                // bounded number of forward/adjoint solves; without this the inner solver dominates
+                // the run cost (the immersed forward+adjoint solve is expensive).
+                tAugLag.set( "Subproblem Iteration Limit", (int)mSubproblemIterationLimit );
+                // Print the inner (Lin-More TR) subproblem history — this is where the trust-region
+                // radius trajectory and step accept/reject signals live (the applicability signals).
+                tAugLag.set( "Print Intermediate Optimization History", true );
+            }
+
+            ROL::ParameterList& tSecant = tParameterList.sublist( "General" ).sublist( "Secant" );
+            tSecant.set( "Type", mSecantType );
+            tSecant.set( "Maximum Storage", (int)mSecantStorage );
+            // Use the secant approximation AS the Hessian. Without this ROL finite-differences the
+            // Hessian-vector product from the gradient, firing many extra (expensive) adjoint solves
+            // per iteration; the immersed MORIS gradient is far too costly for that. Matches Plato.
+            tSecant.set( "Use as Hessian", true );
+
+            ROL::ParameterList& tStatus = tParameterList.sublist( "Status Test" );
+            tStatus.set( "Iteration Limit", (int)mMaxIterations );
+            tStatus.set( "Gradient Tolerance", mGradientTol );
+            tStatus.set( "Constraint Tolerance", mConstraintTol );
+            tStatus.set( "Step Tolerance", mStepTol );
+        }
+
+        // finalize and solve (ROL log to stdout so the trust-region trajectory can be harvested)
+        tRolProblem->finalize( false, true, std::cout );
+
+        ROL::Solver< real > tSolver( tRolProblem, tParameterList );
+        tSolver.solve( std::cout );
+
+        ROL::Ptr< const ROL::AlgorithmState< real > > tState = tSolver.getAlgorithmState();
+        MORIS_LOG_INFO( "ROL finished: iterations=%d, objective=%.6e, gnorm=%.3e",
+                tState->iter, tState->value, tState->gnorm );
+
+        // --- leave the MORIS Problem at the final design ----------------------------------------
+        Vector< real > tFinalADVs( tNumADVs );
+        for ( uint iADV = 0; iADV < tNumADVs; ++iADV )
+        {
+            tFinalADVs( iADV ) = ( *tAdvVec )[ iADV ];
+        }
+        this->compute_design_criteria( tFinalADVs );
+#else
+        MORIS_ERROR( false, "MORIS was compiled without ROL support" );
+#endif
+    }
+
+    //----------------------------------------------------------------------------------------------------------------------
+
+}    // namespace moris::opt

--- a/projects/OPT/src/cl_OPT_Algorithm_ROL.hpp
+++ b/projects/OPT/src/cl_OPT_Algorithm_ROL.hpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2022 University of Colorado
+ * Licensed under the MIT license. See LICENSE.txt file in the MORIS root for details.
+ *
+ *------------------------------------------------------------------------------------
+ *
+ * cl_OPT_Algorithm_ROL.hpp
+ *
+ */
+
+#ifndef MORIS_CL_OPT_ALGORITHM_ROL_HPP_
+#define MORIS_CL_OPT_ALGORITHM_ROL_HPP_
+
+#include <string>
+#include <vector>
+
+#include "core.hpp"
+#include "cl_OPT_Algorithm.hpp"
+#include "cl_Parameter_List.hpp"
+#include "cl_OPT_Problem.hpp"
+
+namespace moris::opt
+{
+    /**
+     * @brief Trilinos ROL (Rapid Optimization Library) optimizer wrapper.
+     *
+     * Wraps ROL's trust-region / Lin-More method (the algorithm family Sandia's Plato uses),
+     * with an optional Augmented-Lagrangian outer loop for general constraints. ROL is templated
+     * C++ and consumes the MORIS Problem through the same value/gradient callbacks as the other
+     * algorithms; see cl_OPT_Algorithm_ROL.cpp for the ROL::Objective / ROL::Constraint adapters.
+     *
+     * Header stays free of ROL/Teuchos types so it can be included without the Trilinos headers;
+     * everything ROL-typed lives behind #ifdef MORIS_HAVE_ROL in the .cpp.
+     */
+    class Algorithm_ROL : public Algorithm
+    {
+      private:
+        // --- curated settings mapped onto the ROL ParameterList (see build in rol_solve) ---
+        std::string mStepType;                 // "Trust Region" (bound) / "Augmented Lagrangian" (constrained)
+        std::string mSubproblemModel;          // trust-region subproblem model, e.g. "Lin-More"
+        std::string mSubproblemSolver;         // trust-region subproblem solver, e.g. "Truncated CG"
+        std::string mSecantType;               // Hessian approximation, e.g. "Limited-Memory BFGS"
+        sint        mSecantStorage;            // secant history length
+        real        mInitialTRRadius;          // initial trust-region radius
+        real        mMaxTRRadius;              // maximum trust-region radius
+        bool        mUseAugmentedLagrangian;   // wrap constraints in an AL outer loop
+        sint        mSubproblemIterationLimit; // inner (bound-constrained TR) subproblem iteration cap in the AL loop
+        real        mALInitialPenalty;         // AL initial penalty parameter
+        real        mALPenaltyGrowth;          // AL penalty growth factor
+        real        mGradientTol;              // status-test gradient tolerance
+        real        mConstraintTol;            // status-test constraint tolerance
+        real        mStepTol;                  // status-test step tolerance
+        std::string mXmlFile;                  // optional full ROL ParameterList XML (overrides curated keys)
+
+        // --- shared evaluation cache -------------------------------------------------------
+        // ROL calls the objective and (M2) constraint adapters at the same design point; both a
+        // forward criteria solve and an adjoint gradient solve are expensive, so we cache the ADV
+        // vector each was last evaluated at and skip redundant solves. compute_design_criteria and
+        // compute_design_criteria_gradients populate BOTH objective and constraint quantities in a
+        // single solve, so one entry per stage suffices.
+        std::vector< real > mCriteriaADVs;      // ADVs of the last forward (criteria) solve
+        std::vector< real > mGradientADVs;      // ADVs of the last adjoint (gradient) solve
+        bool                mHaveCriteria  = false;
+        bool                mHaveGradients = false;
+
+      public:
+        /**
+         * Constructor
+         *
+         * @param aParameterList algorithm parameter list (see prm::create_rol_parameter_list)
+         */
+        explicit Algorithm_ROL( const Parameter_List& aParameterList );
+
+        /**
+         * Destructor
+         */
+        ~Algorithm_ROL() override;
+
+        /**
+         * @brief MORIS interface for solving the optimization problem using ROL
+         *
+         * @param[in] aCurrentOptAlgInd index of optimization algorithm
+         * @param[in] aOptProb          Problem holding ADVs, objective and constraints
+         */
+        uint solve(
+                uint                       aCurrentOptAlgInd,
+                std::shared_ptr< Problem > aOptProb ) override;
+
+        /**
+         * @brief Run the ROL solver (rank 0 only). Builds the ROL problem + parameter list and
+         *        drives ROL::Solver; no-op MORIS_ERROR when compiled without ROL.
+         */
+        void rol_solve();
+
+        /**
+         * @brief Record an accepted design iterate (writes the restart file). Called by the ROL
+         *        objective adapter's update() only on ROL::UpdateType::Accept, so restart files are
+         *        written once per accepted step rather than once per (trial) forward evaluation.
+         */
+        void notify_accepted_step( const std::vector< real >& aADVs );
+
+        /**
+         * @brief Ensure design criteria (objective + constraints) are current at aADVs.
+         *        Triggers a forward criteria solve only if aADVs differ from the cached point.
+         *        Called by the ROL::Objective / ROL::Constraint adapters.
+         */
+        void ensure_criteria( const std::vector< real >& aADVs );
+
+        /**
+         * @brief Ensure design-criteria gradients are current at aADVs (implies ensure_criteria).
+         *        Triggers an adjoint gradient solve only if aADVs differ from the cached point.
+         */
+        void ensure_gradients( const std::vector< real >& aADVs );
+    };
+}    // namespace moris::opt
+
+#endif /* MORIS_CL_OPT_ALGORITHM_ROL_HPP_ */

--- a/projects/OPT/src/fn_OPT_create_algorithm.cpp
+++ b/projects/OPT/src/fn_OPT_create_algorithm.cpp
@@ -14,6 +14,7 @@
 #include "cl_OPT_Algorithm_SQP.hpp"
 #include "cl_OPT_Algorithm_LBFGS.hpp"
 #include "cl_OPT_Algorithm_Sweep.hpp"
+#include "cl_OPT_Algorithm_ROL.hpp"
 
 namespace moris::opt
 {
@@ -40,6 +41,10 @@ namespace moris::opt
         else if ( tAlgorithmName == "sweep" )
         {
             return std::make_shared< Algorithm_Sweep >( aAlgorithmParameterList );
+        }
+        else if ( tAlgorithmName == "rol" )
+        {
+            return std::make_shared< Algorithm_ROL >( aAlgorithmParameterList );
         }
         else
         {

--- a/projects/OPT/test/opt_test.cpp
+++ b/projects/OPT/test/opt_test.cpp
@@ -10,6 +10,9 @@
 
 #include <catch.hpp>
 
+#include <fstream>
+#include <cstdio>
+
 #include "fn_PRM_OPT_Parameters.hpp"
 #include "cl_OPT_Manager.hpp"
 #include "fn_OPT_create_interface.hpp"
@@ -417,6 +420,196 @@ namespace moris::opt
                 {
                     REQUIRE( std::abs( iADV - 1.0 ) < 1E-4 );
                 }
+            }
+        }
+#endif
+
+        // ---------------------------------------------------------------------------------------------------------
+
+#ifdef MORIS_HAVE_ROL
+        // Trilinos ROL trust-region (Lin-More) bridge, BOUND-CONSTRAINED. With
+        // use_augmented_lagrangian = false the general constraints are ignored (like the LBFGS
+        // case above); the bound-constrained Rosenbrock minimum is (1,1).
+        SECTION( "ROL bound-constrained" )
+        {
+            // Set up default parameter lists
+            Parameter_List tProblemParameterList   = moris::prm::create_opt_problem_parameter_list();
+            Parameter_List tAlgorithmParameterList = moris::prm::create_rol_parameter_list();
+
+            tAlgorithmParameterList.set( "use_augmented_lagrangian", false );
+            tAlgorithmParameterList.set( "max_its", 200 );
+            tAlgorithmParameterList.set( "initial_tr_radius", 1.0 );
+            tAlgorithmParameterList.set( "gradient_tol", 1.0e-12 );
+
+            // Create interface
+            std::shared_ptr< Criteria_Interface > tInterface = std::make_shared< Interface_User_Defined >(
+                    &initialize_rosenbrock,
+                    &get_criteria_rosenbrock,
+                    &get_dcriteria_dadv_rosenbrock );
+
+            // Create Problem
+            std::shared_ptr< Problem > tProblem = std::make_shared< Problem_User_Defined >(
+                    tProblemParameterList,
+                    tInterface,
+                    &get_constraint_types_rosenbrock,
+                    &compute_objectives_rosenbrock,
+                    &compute_constraints_rosenbrock,
+                    &compute_dobjective_dadv_rosenbrock,
+                    &compute_dobjective_dcriteria_rosenbrock,
+                    &compute_dconstraint_dadv_rosenbrock,
+                    &compute_dconstraint_dcriteria_rosenbrock );
+
+            // Create manager
+            Submodule_Parameter_Lists tAlgorithms( "Algorithms" );
+            tAlgorithms.add_parameter_list( tAlgorithmParameterList );
+            Manager tManager( tAlgorithms, tProblem );
+
+            // Solve optimization problem
+            tManager.perform();
+
+            // Check Solution
+            if ( par_rank() == 0 )
+            {
+                REQUIRE( std::abs( tManager.get_objectives()( 0 ) ) < 1E-6 );    // check value of objective
+                Vector< real > tADVs = tManager.get_advs();
+                for ( auto iADV : tADVs )
+                {
+                    REQUIRE( std::abs( iADV - 1.0 ) < 1E-3 );
+                }
+            }
+        }
+
+        // ---------------------------------------------------------------------------------------------------------
+
+        // ROL with the AUGMENTED-LAGRANGIAN outer loop over the two (inequality) Rosenbrock
+        // constraints. Both constraints are active (= 0) at the unconstrained minimum (1,1), which
+        // is therefore also the constrained minimizer -- so the AL path must land at (1,1) too.
+        SECTION( "ROL augmented Lagrangian" )
+        {
+            // Set up default parameter lists
+            Parameter_List tProblemParameterList   = moris::prm::create_opt_problem_parameter_list();
+            Parameter_List tAlgorithmParameterList = moris::prm::create_rol_parameter_list();
+
+            tAlgorithmParameterList.set( "max_its", 100 );
+            tAlgorithmParameterList.set( "initial_tr_radius", 1.0 );
+
+            // Create interface
+            std::shared_ptr< Criteria_Interface > tInterface = std::make_shared< Interface_User_Defined >(
+                    &initialize_rosenbrock,
+                    &get_criteria_rosenbrock,
+                    &get_dcriteria_dadv_rosenbrock );
+
+            // Create Problem
+            std::shared_ptr< Problem > tProblem = std::make_shared< Problem_User_Defined >(
+                    tProblemParameterList,
+                    tInterface,
+                    &get_constraint_types_rosenbrock,
+                    &compute_objectives_rosenbrock,
+                    &compute_constraints_rosenbrock,
+                    &compute_dobjective_dadv_rosenbrock,
+                    &compute_dobjective_dcriteria_rosenbrock,
+                    &compute_dconstraint_dadv_rosenbrock,
+                    &compute_dconstraint_dcriteria_rosenbrock );
+
+            // Create manager
+            Submodule_Parameter_Lists tAlgorithms( "Algorithms" );
+            tAlgorithms.add_parameter_list( tAlgorithmParameterList );
+            Manager tManager( tAlgorithms, tProblem );
+
+            // Solve optimization problem
+            tManager.perform();
+
+            // Check Solution
+            if ( par_rank() == 0 )
+            {
+                REQUIRE( std::abs( tManager.get_objectives()( 0 ) ) < 1E-4 );    // check value of objective
+                Vector< real > tADVs = tManager.get_advs();
+                for ( auto iADV : tADVs )
+                {
+                    REQUIRE( std::abs( iADV - 1.0 ) < 1E-2 );
+                }
+            }
+        }
+
+        // ---------------------------------------------------------------------------------------------------------
+
+        // ROL driven by a full ROL/Teuchos ParameterList XML (the "xml_file" escape hatch, e.g.
+        // Plato's rol_inputs.xml). Confirms the passthrough path parses the XML and drives ROL;
+        // bound-constrained so the XML "Trust Region" step matches (constraints off).
+        SECTION( "ROL xml passthrough" )
+        {
+            // Write a minimal ROL parameter XML (rank 0 writes; the solver runs on rank 0)
+            const std::string tXmlPath = "./rol_passthrough_test.xml";
+            if ( par_rank() == 0 )
+            {
+                std::ofstream tXml( tXmlPath );
+                tXml << "<ParameterList>\n"
+                     << "  <ParameterList name=\"Step\">\n"
+                     << "    <Parameter name=\"Type\" type=\"string\" value=\"Trust Region\"/>\n"
+                     << "    <ParameterList name=\"Trust Region\">\n"
+                     << "      <Parameter name=\"Subproblem Model\" type=\"string\" value=\"Lin-More\"/>\n"
+                     << "      <Parameter name=\"Subproblem Solver\" type=\"string\" value=\"Truncated CG\"/>\n"
+                     << "      <Parameter name=\"Initial Radius\" type=\"double\" value=\"1.0\"/>\n"
+                     << "    </ParameterList>\n"
+                     << "  </ParameterList>\n"
+                     << "  <ParameterList name=\"General\">\n"
+                     << "    <ParameterList name=\"Secant\">\n"
+                     << "      <Parameter name=\"Type\" type=\"string\" value=\"Limited-Memory BFGS\"/>\n"
+                     << "      <Parameter name=\"Use as Hessian\" type=\"bool\" value=\"true\"/>\n"
+                     << "    </ParameterList>\n"
+                     << "  </ParameterList>\n"
+                     << "  <ParameterList name=\"Status Test\">\n"
+                     << "    <Parameter name=\"Iteration Limit\" type=\"int\" value=\"200\"/>\n"
+                     << "    <Parameter name=\"Gradient Tolerance\" type=\"double\" value=\"1.0e-12\"/>\n"
+                     << "  </ParameterList>\n"
+                     << "</ParameterList>\n";
+            }
+            barrier();
+
+            // Set up default parameter lists
+            Parameter_List tProblemParameterList   = moris::prm::create_opt_problem_parameter_list();
+            Parameter_List tAlgorithmParameterList = moris::prm::create_rol_parameter_list();
+
+            tAlgorithmParameterList.set( "use_augmented_lagrangian", false );
+            tAlgorithmParameterList.set( "xml_file", tXmlPath );
+
+            // Create interface
+            std::shared_ptr< Criteria_Interface > tInterface = std::make_shared< Interface_User_Defined >(
+                    &initialize_rosenbrock,
+                    &get_criteria_rosenbrock,
+                    &get_dcriteria_dadv_rosenbrock );
+
+            // Create Problem
+            std::shared_ptr< Problem > tProblem = std::make_shared< Problem_User_Defined >(
+                    tProblemParameterList,
+                    tInterface,
+                    &get_constraint_types_rosenbrock,
+                    &compute_objectives_rosenbrock,
+                    &compute_constraints_rosenbrock,
+                    &compute_dobjective_dadv_rosenbrock,
+                    &compute_dobjective_dcriteria_rosenbrock,
+                    &compute_dconstraint_dadv_rosenbrock,
+                    &compute_dconstraint_dcriteria_rosenbrock );
+
+            // Create manager
+            Submodule_Parameter_Lists tAlgorithms( "Algorithms" );
+            tAlgorithms.add_parameter_list( tAlgorithmParameterList );
+            Manager tManager( tAlgorithms, tProblem );
+
+            // Solve optimization problem
+            tManager.perform();
+
+            // Check Solution
+            if ( par_rank() == 0 )
+            {
+                REQUIRE( std::abs( tManager.get_objectives()( 0 ) ) < 1E-6 );    // check value of objective
+                Vector< real > tADVs = tManager.get_advs();
+                for ( auto iADV : tADVs )
+                {
+                    REQUIRE( std::abs( iADV - 1.0 ) < 1E-3 );
+                }
+
+                std::remove( tXmlPath.c_str() );
             }
         }
 #endif

--- a/projects/PRM/src/fn_PRM_OPT_Parameters.hpp
+++ b/projects/PRM/src/fn_PRM_OPT_Parameters.hpp
@@ -20,7 +20,8 @@ namespace moris::opt
         MMA,
         LBFGS,
         SQP,
-        SWEEP
+        SWEEP,
+        ROL
     };
 }
 
@@ -310,6 +311,48 @@ namespace moris::prm
         return tParameterList;
     }
 
+    //--------------------------------------------------------------------------------------------------------------
+
+    inline Parameter_List
+    create_rol_parameter_list()
+    {
+        // Trilinos ROL (Rapid Optimization Library) trust-region optimizer -- the algorithm family
+        // Sandia's Plato uses. Curated keys map onto ROL's Teuchos ParameterList (see rol_solve);
+        // set "xml_file" to a ROL parameter XML (e.g. Plato's rol_inputs.xml) to bypass these keys.
+        Parameter_List tParameterList( "ROL" );
+
+        tParameterList.insert( "algorithm", "rol" );    // Algorithm name, don't change
+        tParameterList.insert( "restart_index", 0 );    // Restart iteration index
+        tParameterList.insert( "max_its", 100 );        // Maximum number of (outer) iterations
+
+        // Step / trust-region / Lin-More configuration
+        tParameterList.insert( "step_type", "Trust Region" );          // "Trust Region" or "Augmented Lagrangian"
+        tParameterList.insert( "subproblem_model", "Lin-More" );       // trust-region subproblem model
+        tParameterList.insert( "subproblem_solver", "Truncated CG" );  // trust-region subproblem solver
+        tParameterList.insert( "initial_tr_radius", 10.0 );            // initial trust-region radius
+        tParameterList.insert( "max_tr_radius", 5.0e3 );               // maximum trust-region radius
+
+        // Hessian approximation (secant)
+        tParameterList.insert( "secant_type", "Limited-Memory BFGS" );    // Hessian approximation type
+        tParameterList.insert( "secant_storage", 10 );                    // secant history length
+
+        // Augmented-Lagrangian outer loop (used when general constraints are present)
+        tParameterList.insert( "use_augmented_lagrangian", true );      // wrap constraints in an AL outer loop
+        tParameterList.insert( "subproblem_iteration_limit", 25 );      // inner (TR) subproblem iteration cap per AL outer step
+        tParameterList.insert( "al_initial_penalty", 10.0 );           // AL initial penalty parameter
+        tParameterList.insert( "al_penalty_growth", 100.0 );           // AL penalty growth factor
+
+        // Status-test tolerances
+        tParameterList.insert( "gradient_tol", 1.0e-10 );      // gradient (optimality) tolerance
+        tParameterList.insert( "constraint_tol", 1.0e-10 );    // constraint (feasibility) tolerance
+        tParameterList.insert( "step_tol", 1.0e-14 );          // step tolerance
+
+        // Optional full ROL ParameterList XML; empty -> build the list from the curated keys above
+        tParameterList.insert( "xml_file", "" );
+
+        return tParameterList;
+    }
+
     /**
      * Creates an optimization algorithm parameter list depending on the optimziation algorithm type given.
      *
@@ -330,6 +373,8 @@ namespace moris::prm
                 return create_sqp_parameter_list();
             case opt::Optimization_Algorithm_Type::SWEEP:
                 return create_sweep_parameter_list();
+            case opt::Optimization_Algorithm_Type::ROL:
+                return create_rol_parameter_list();
             default:
                 MORIS_ERROR( false, "Unknown optimization algorithm type provided." );
                 return Parameter_List( "Error" );

--- a/share/cmake/dependencies/OPT_Depends.cmake
+++ b/share/cmake/dependencies/OPT_Depends.cmake
@@ -35,7 +35,12 @@ endif()
 if(${MORIS_HAVE_LBFGS})
     list(APPEND OPT_TPL_DEPENDENCIES "lbfgsb")
 endif()
-    
+
+# Include trilinos (provides ROL) if the ROL optimizer is used
+if(${MORIS_HAVE_ROL})
+    list(APPEND OPT_TPL_DEPENDENCIES "trilinos")
+endif()
+
 
 # Make sure needed moris libraries are built
 include(${MORIS_DEPENDS_DIR}/LINALG_Depends.cmake)


### PR DESCRIPTION
## Summary

Adds **Trilinos ROL** (Rapid Optimization Library) as a new `Optimization_Algorithm_Type` in the OPT module — the trust-region optimizer family Sandia's Plato uses (Type-B trust region + Lin-More subproblem + Augmented-Lagrangian outer loop for general constraints).

ROL already ships inside the Trilinos MORIS links (`trilinos@15.1.1`, `rol=True`; `librol` is effectively header-only), so this is a **pure OPT-side change with no new TPL** — just a new `MORIS_HAVE_ROL` option that links `${MORIS}::trilinos` for OPT.

## What's included

- **`cl_OPT_Algorithm_ROL.{hpp,cpp}`** — `Algorithm_ROL` deriving from `moris::opt::Algorithm`. `ROL::Objective`/`ROL::Constraint` adapters forward into the existing `Problem`/`Criteria_Interface` via a shared criteria/gradient cache (so ROL's trust-region *trial* evaluations don't re-trigger the expensive forward/adjoint solves). `ROL::StdVector` ADV bridge + `ROL::Bounds`; the rank-0-drives / `dummy_solve` parallel pattern mirroring GCMMA/SQP. Restart files written on *accepted* steps only; the L-BFGS secant is used **as** the Hessian (avoids a finite-difference-Hessian adjoint blowup). All ROL code is guarded by `#ifdef MORIS_HAVE_ROL` with a `MORIS_ERROR` fallback.
- **`fn_PRM_OPT_Parameters.hpp`** — `ROL` enum + `create_rol_parameter_list()` (curated Lin-More/TR/AL keys + `subproblem_iteration_limit` + an optional `xml_file` full-ParameterList passthrough, e.g. Plato's `rol_inputs.xml`).
- **`fn_OPT_create_algorithm.cpp`** — `"rol"` factory branch.
- **CMake** — `MORIS_HAVE_ROL` option + `-DMORIS_HAVE_ROL`; `OPT_Depends.cmake` links `${MORIS}::trilinos` when enabled.
- **`opt_test.cpp`** — three `#ifdef MORIS_HAVE_ROL` Rosenbrock sections: bound-constrained TR, Augmented-Lagrangian (inequality constraints), and `xml_file` passthrough. All pass.

## Testing

- `OPT-test` green, including the three new ROL sections (bound-constrained → 20 iters/obj 4e-28; AL → obj 8e-18 at the constrained optimum; xml passthrough matches the curated path).
- Exercised end-to-end on a real immersed level-set L-bracket topology-optimization deck (forward solve → adjoint → trust-region step, volume constraint via AL, ADV box bounds): converges to feasible designs; validated against GCMMA at 50²/100².

CI should confirm the build on `develop` with `MORIS_HAVE_ROL=ON` (default) and the fallback with it OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PVuV83efJYZ2XpTPXaR9sm